### PR TITLE
Restore WorkspaceList.from_json_string

### DIFF
--- a/PermutiveAPI/Workspace.py
+++ b/PermutiveAPI/Workspace.py
@@ -1,4 +1,5 @@
-from typing import Dict, List, Optional, Any,overload,Type,Union
+from typing import Dict, List, Optional, Any, overload, Type, Union
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from PermutiveAPI.Utils import JSONSerializable
@@ -104,3 +105,8 @@ class WorkspaceList(List[Workspace], JSONSerializable):
     def to_list(self) -> List[Workspace]:
         """Returns the list of workspaces."""
         return list(self)
+
+    @classmethod
+    def from_json_string(cls, json_string: str) -> "WorkspaceList":
+        """Create a ``WorkspaceList`` from a JSON string."""
+        return cls.from_json(json_string)


### PR DESCRIPTION
## Summary
- add `json` import to Workspace module
- implement `WorkspaceList.from_json_string` for convenience

## Testing
- `python -m pip install -r requirements.txt`
- `python -m pip install -e .` *(fails: Operation cancelled due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_6857e70f8d7c832990be75ea2befe334