### PR TITLE
Add tests for utility helpers

### DIFF
--- a/PermutiveAPI/Cohort.py
+++ b/PermutiveAPI/Cohort.py
@@ -4,7 +4,7 @@ import logging
 from typing import Dict, List, Optional, Union
 from dataclasses import dataclass, field
 from datetime import datetime
-from PermutiveAPI.utils import RequestHelper, JSONSerializable
+from PermutiveAPI.Utils import RequestHelper, JSONSerializable
 from collections import defaultdict
 
 _API_VERSION = "v2"

--- a/PermutiveAPI/User.py
+++ b/PermutiveAPI/User.py
@@ -5,7 +5,7 @@ from typing import List
 from dataclasses import dataclass
 from datetime import datetime
 
-from PermutiveAPI.utils import RequestHelper, JSONSerializable
+from PermutiveAPI.Utils import RequestHelper, JSONSerializable
 
 
 _API_VERSION = 'v2.0'

--- a/PermutiveAPI/Workspace.py
+++ b/PermutiveAPI/Workspace.py
@@ -3,9 +3,9 @@
 from typing import Dict, List, Optional, Any, overload, Type, Union
 from dataclasses import dataclass
 from pathlib import Path
-from PermutiveAPI.utils import JSONSerializable
+from PermutiveAPI.Utils import JSONSerializable
 from PermutiveAPI.source import Import, Segment
-from PermutiveAPI.cohort import Cohort, CohortList
+from PermutiveAPI.Cohort import Cohort, CohortList
 
 
 @dataclass

--- a/PermutiveAPI/__init__.py
+++ b/PermutiveAPI/__init__.py
@@ -7,10 +7,10 @@ the repository root for installation and full usage documentation.
 """
 
 from PermutiveAPI.source import Import, ImportList, Segment, SegmentList
-from PermutiveAPI.user import Identity, Alias
-from PermutiveAPI.cohort import Cohort, CohortList
-from PermutiveAPI.workspace import Workspace, WorkspaceList
-from PermutiveAPI.utils import customJSONEncoder
+from PermutiveAPI.User import Identity, Alias
+from PermutiveAPI.Cohort import Cohort, CohortList
+from PermutiveAPI.Workspace import Workspace, WorkspaceList
+from PermutiveAPI.Utils import customJSONEncoder
 
 
 

--- a/PermutiveAPI/source.py
+++ b/PermutiveAPI/source.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from collections import defaultdict
 
 
-from PermutiveAPI.utils import RequestHelper,  JSONSerializable
+from PermutiveAPI.Utils import RequestHelper, JSONSerializable
 
 
 _API_VERSION = "v1"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,65 @@
+"""Tests for helper utilities in :mod:`PermutiveAPI.Utils`."""
+
+import sys
+from pathlib import Path
+import unittest
+from tempfile import TemporaryDirectory
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from PermutiveAPI.Utils import RequestHelper, ListHelper, FileHelper
+
+
+class TestRequestHelper(unittest.TestCase):
+    """Tests for :class:`RequestHelper`."""
+
+    def test_generate_url_with_key_no_query(self) -> None:
+        """Append API key with ``?`` when the URL lacks query parameters."""
+        url = "https://api.example.com/resource"
+        result = RequestHelper.generate_url_with_key(url, "abc123")
+        self.assertEqual(result, "https://api.example.com/resource?k=abc123")
+
+    def test_generate_url_with_key_with_query(self) -> None:
+        """Append API key with ``&`` when the URL already has a query."""
+        url = "https://api.example.com/resource?x=1"
+        result = RequestHelper.generate_url_with_key(url, "abc123")
+        self.assertEqual(result, "https://api.example.com/resource?x=1&k=abc123")
+
+
+class TestListHelper(unittest.TestCase):
+    """Tests for list utility helpers."""
+
+    def test_merge_list_with_duplicates_and_sort(self) -> None:
+        """Merge lists, remove duplicates and sort the result."""
+        merged = ListHelper.merge_list([3, 1, 2], [2, 4])
+        self.assertEqual(merged, [1, 2, 3, 4])
+
+    def test_merge_list_with_single_value(self) -> None:
+        """Handle merging when the second argument is a scalar."""
+        merged = ListHelper.merge_list(["b", "a"], "c")
+        self.assertEqual(merged, ["a", "b", "c"])
+
+
+class TestFileHelper(unittest.TestCase):
+    """Tests for file helper utilities."""
+
+    def test_split_filepath(self) -> None:
+        """Split filepath into directory, base name and extension."""
+        path = "/tmp/data/report.tar.gz"
+        file_path, file_name, file_ext = FileHelper.split_filepath(path)
+        self.assertEqual(file_path, "/tmp/data/")
+        self.assertEqual(file_name, "report")
+        self.assertEqual(file_ext, ".tar.gz")
+
+    def test_file_exists_with_pattern(self) -> None:
+        """Detect existing files matching the pattern ``<name>-*<ext>``."""
+        with TemporaryDirectory() as tmpdir:
+            file_with_suffix = Path(tmpdir) / "report-123.txt"
+            file_with_suffix.write_text("data", encoding="utf-8")
+            self.assertTrue(FileHelper.file_exists(str(Path(tmpdir) / "report.txt")))
+            self.assertFalse(FileHelper.file_exists(str(Path(tmpdir) / "missing.txt")))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- Fix module import casing to match file names
- Add tests for RequestHelper, ListHelper, and FileHelper utilities

## Testing
- `pydocstyle PermutiveAPI`
- `pyright PermutiveAPI`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689226eead8c8329b2666212f1f6bc88