### PR TITLE
Refactor and improve the PermutiveAPI codebase

### DIFF
--- a/PermutiveAPI/Cohort.py
+++ b/PermutiveAPI/Cohort.py
@@ -120,7 +120,7 @@ class Cohort(JSONSerializable):
         Returns:
             None
         """
-        logging.debug(f"{datetime.now()}::CohortAPI::delete::{self.name}")
+        logging.debug(f"CohortAPI::delete::{self.name}")
         if not self.id:
             raise ValueError("Cohort ID must be specified for deletion.")
         url = f"{_API_ENDPOINT}{self.id}"
@@ -142,7 +142,7 @@ class Cohort(JSONSerializable):
         Raises:
             ValueError: If the cohort cannot be fetched.
         """
-        logging.debug(f"{datetime.now()}::CohortAPI::get::{id}")
+        logging.debug(f"CohortAPI::get::{id}")
         url = f"{_API_ENDPOINT}{id}"
         response = RequestHelper.get_static(api_key=api_key,
                                             url=url)
@@ -171,14 +171,11 @@ class Cohort(JSONSerializable):
         Returns:
             Optional[Cohort]: The matching cohort if found, otherwise ``None``.
         """
-        logging.debug(f"{datetime.now()}::CohortAPI::get_by_name::{name}")
+        logging.debug(f"CohortAPI::get_by_name::{name}")
 
-        for cohort in Cohort.list(include_child_workspaces=True,
-                                  api_key=api_key):
-            if name == cohort.name and cohort.id:
-                return Cohort.get_by_id(id=cohort.id,
-                                        api_key=api_key)
-        return None
+        cohorts = Cohort.list(include_child_workspaces=True,
+                                  api_key=api_key)
+        return cohorts.name_dictionary.get(name)
 
     @staticmethod
     def get_by_code(
@@ -195,13 +192,10 @@ class Cohort(JSONSerializable):
         Returns:
             Optional[Cohort]: The matching cohort if found, otherwise ``None``.
         """
-        logging.debug(f"{datetime.now()}::CohortAPI::get_by_code::{code}")
-        for cohort in Cohort.list(include_child_workspaces=True,
-                                  api_key=api_key):
-            if code == cohort.code and cohort.id:
-                return Cohort.get_by_id(id=cohort.id,
-                                        api_key=api_key)
-        return None
+        logging.debug(f"CohortAPI::get_by_code::{code}")
+        cohorts = Cohort.list(include_child_workspaces=True,
+                                  api_key=api_key)
+        return cohorts.code_dictionary.get(str(code))
 
     @staticmethod
     def list(api_key: str,
@@ -218,10 +212,9 @@ class Cohort(JSONSerializable):
         """
         logging.debug(f"CohortAPI::list")
 
-        url = RequestHelper.generate_url_with_key(url=_API_ENDPOINT,
-                                                  api_key=api_key)
+        url = _API_ENDPOINT
         if include_child_workspaces:
-            url = f"{url}&include-child-workspaces=true"
+            url += "?include-child-workspaces=true"
 
         response = RequestHelper.get_static(api_key, url)
         if response is None:

--- a/PermutiveAPI/Source.py
+++ b/PermutiveAPI/Source.py
@@ -107,7 +107,7 @@ class Import(JSONSerializable):
         Returns:
             Import: The requested import.
         """
-        logging.debug(f"{datetime.now()}::AudienceAPI::get_import::{id}")
+        logging.debug(f"AudienceAPI::get_import::{id}")
         url = f"{_API_ENDPOINT}/{id}"
         response = RequestHelper.get_static(url=url,
                                             api_key=api_key)
@@ -117,16 +117,16 @@ class Import(JSONSerializable):
 
     @classmethod
     def list(cls,
-             api_key: str) -> List['Import']:
+             api_key: str) -> 'ImportList':
         """Retrieve a list of all imports.
 
         Args:
             api_key (str): The API key for authentication.
 
         Returns:
-            List[Import]: A list of Import objects.
+            ImportList: A list of Import objects.
         """
-        logging.debug(f"{datetime.now()}::AudienceAPI::list_imports")
+        logging.debug(f"AudienceAPI::list_imports")
         url = _API_ENDPOINT
         response = RequestHelper.get_static(
             api_key=api_key, url=url)
@@ -141,7 +141,7 @@ class Import(JSONSerializable):
                 item['source'] = source_instance
             return cls(**item)
 
-        return [create_import(item) for item in imports['items']]
+        return ImportList([create_import(item) for item in imports['items']])
 
 
 class ImportList(List[Import],
@@ -349,36 +349,6 @@ class Segment(JSONSerializable):
         return response.status_code == 204
 
     @staticmethod
-    def get(import_id: str,
-            segment_id: str,
-            api_key: str) -> 'Segment':
-        """Retrieve a segment by its import ID and segment ID.
-
-        Args:
-            import_id (str): The ID of the import.
-            segment_id (str): The ID of the segment.
-            api_key (str): The private key for authentication.
-
-        Returns:
-            Segment: The segment object retrieved from the API.
-
-        Raises:
-            ValueError: If the segment cannot be retrieved.
-        """
-        logging.debug(
-            f"SegmentAPI::get_segment_by_id::{import_id}::{segment_id}")
-        url = f"{_API_ENDPOINT}/{import_id}/segments/{segment_id}"
-        response = RequestHelper.get_static(api_key,
-                                            url=url)
-        if not response:
-            raise ValueError('Unable to get_segment')
-        segment = Segment.from_json(response.json())
-        if isinstance(segment, Segment):
-            return segment
-        else:
-            raise ValueError('Segment not found or invalid response format')
-
-    @staticmethod
     def get_by_code(import_id: str,
                     segment_code: str,
                     api_key: str) -> 'Segment':
@@ -407,7 +377,6 @@ class Segment(JSONSerializable):
             return segment
         else:
             raise ValueError('Segment not found or invalid response format')
-        return Segment.from_json(response.json())
 
     @staticmethod
     def get_by_id(import_id: str,
@@ -426,7 +395,6 @@ class Segment(JSONSerializable):
         Raises:
             ValueError: If the segment cannot be retrieved.
         """
-        logging.debug(f"{datetime.now()}::SegmentAPI::get_segment:{id}")
         logging.debug(
             f"SegmentAPI::get_segment_by_id::{import_id}::{segment_id}")
         url = f"{_API_ENDPOINT}/{import_id}/segments/{segment_id}"
@@ -456,7 +424,7 @@ class Segment(JSONSerializable):
             requests.exceptions.RequestException: If an error occurs while making
                 the API request.
         """
-        logging.debug(f"{datetime.now()}::SegmentAPI::list")
+        logging.debug(f"SegmentAPI::list")
 
         base_url = f"{_API_ENDPOINT}/{import_id}/segments"
         all_segments = []

--- a/PermutiveAPI/User.py
+++ b/PermutiveAPI/User.py
@@ -60,8 +60,7 @@ class Identity(JSONSerializable):
         Returns:
             Response: The response from the Permutive API.
         """
-        logging.debug(
-            f"{datetime.now()}::UserAPI::identify::{self.user_id}")
+        logging.debug(f"UserAPI::identify::{self.user_id}")
 
         url = f"{_API_ENDPOINT}"
 

--- a/PermutiveAPI/Utils.py
+++ b/PermutiveAPI/Utils.py
@@ -317,10 +317,9 @@ class RequestHelper:
                 msg = RequestHelper._extract_error_message(response)
                 # Redact sensitive data from both the error message and the request URL
                 msg = RequestHelper._redact_sensitive_data(msg, response)
-                if hasattr(response, "request") and hasattr(response.request, "url"):
+                redacted_url = ""
+                if hasattr(response, "request") and response.request.url:
                     redacted_url = RequestHelper._redact_sensitive_data(response.request.url, response)
-                else:
-                    redacted_url = ""
                 logging.warning(f"400 Bad Request: {msg}" + (f" [URL: {redacted_url}]" if redacted_url else ""))
                 return response
 

--- a/PermutiveAPI/Workspace.py
+++ b/PermutiveAPI/Workspace.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional, Any, overload, Type, Union
 from dataclasses import dataclass
 from pathlib import Path
 from PermutiveAPI.Utils import JSONSerializable
-from PermutiveAPI.Source import Import, Segment
+from PermutiveAPI.Source import Import, ImportList, Segment
 from PermutiveAPI.Cohort import Cohort, CohortList
 
 
@@ -64,11 +64,11 @@ class Workspace(JSONSerializable):
                            api_key=self.api_key)
 
     @property
-    def imports(self) -> List[Import]:
+    def imports(self) -> "ImportList":
         """Retrieve a cached list of imports for the workspace.
 
         Returns:
-            List[Import]: Cached list of imports.
+            ImportList: Cached list of imports.
         """
         if not hasattr(self, '_import_cache'):
             self._import_cache = Import.list(api_key=self.api_key)

--- a/tests/test_cohort.py
+++ b/tests/test_cohort.py
@@ -87,17 +87,14 @@ class TestCohort(unittest.TestCase):
     @patch('PermutiveAPI.Cohort.Cohort.list')
     def test_get_by_name(self, mock_list):
         # Arrange
-        mock_list.return_value = [self.cohort]
+        mock_list.return_value = CohortList([self.cohort])
 
-        with patch('PermutiveAPI.Cohort.Cohort.get_by_id') as mock_get_by_id:
-            mock_get_by_id.return_value = self.cohort
-            # Act
-            found_cohort = Cohort.get_by_name("Test Cohort", self.api_key)
+        # Act
+        found_cohort = Cohort.get_by_name("Test Cohort", self.api_key)
 
-            # Assert
-            mock_list.assert_called_once_with(include_child_workspaces=True, api_key=self.api_key)
-            mock_get_by_id.assert_called_once_with(id=self.cohort.id, api_key=self.api_key)
-            self.assertEqual(found_cohort, self.cohort)
+        # Assert
+        mock_list.assert_called_once_with(include_child_workspaces=True, api_key=self.api_key)
+        self.assertEqual(found_cohort, self.cohort)
 
     @patch('PermutiveAPI.Cohort.RequestHelper.get_static')
     def test_list_cohorts(self, mock_get):

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -146,20 +146,6 @@ class TestSegment(unittest.TestCase):
         self.assertTrue(result)
 
     @patch('PermutiveAPI.Source.RequestHelper.get_static')
-    def test_get(self, mock_get):
-        # Arrange
-        mock_response = MagicMock()
-        mock_response.json.return_value = self.segment_data
-        mock_get.return_value = mock_response
-
-        # Act
-        result = Segment.get("import-123", "seg-123", self.api_key)
-
-        # Assert
-        mock_get.assert_called_once()
-        self.assertEqual(result.id, "seg-123")
-
-    @patch('PermutiveAPI.Source.RequestHelper.get_static')
     def test_get_by_code(self, mock_get):
         # Arrange
         mock_response = MagicMock()


### PR DESCRIPTION
This commit addresses several issues found during a manual code review, improving code quality, consistency, and efficiency.

Key changes include:

- Removed redundant `datetime.now()` calls from logging statements, relying on the logging framework for timestamps.
- Refactored `Cohort.get_by_name` and `Cohort.get_by_code` to use the caching mechanism in `CohortList`, avoiding unnecessary API calls.
- Fixed a bug in `Cohort.list` where the API key was being added to the URL twice.
- Removed duplicate and unreachable code in the `Segment` class, including a redundant `get` method and a duplicate `get_by_id` method.
- Changed `Import.list` to return an `ImportList` for consistency and to enable caching.
- Fixed a type hint for the `Workspace.imports` property.
- Fixed a type error in `PermutiveAPI/Utils.py` found by `pyright`.
- Updated tests to reflect the refactoring changes.