### PR TITLE
Use default_factory for Import.updated_at

### DIFF
--- a/PermutiveAPI/Import.py
+++ b/PermutiveAPI/Import.py
@@ -2,7 +2,7 @@
 
 import logging
 from typing import Dict, List, Optional, DefaultDict, TYPE_CHECKING
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 if TYPE_CHECKING:
     from PermutiveAPI.Segment import SegmentList
@@ -54,7 +54,7 @@ class Import(JSONSerializable):
     description: Optional[str] = None
     inheritance: Optional[str] = None
     segments: Optional['SegmentList'] = None
-    updated_at: Optional[datetime] = datetime.now()
+    updated_at: Optional[datetime] = field(default_factory=datetime.now)
 
     @classmethod
     def get_by_id(cls,


### PR DESCRIPTION
## Summary
- Import `field` from `dataclasses` and use it for `Import.updated_at`

## Testing
- `pydocstyle PermutiveAPI`
- `pyright PermutiveAPI`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689726983bc88329a144683fb5e0354c