### PR TITLE
Use urllib.parse to append API key to URL

### DIFF
--- a/PermutiveAPI/Utils.py
+++ b/PermutiveAPI/Utils.py
@@ -64,7 +64,9 @@ class RequestHelper:
     def generate_url_with_key(url: str,
                               api_key: str) -> str:
         """
-        Generate a URL with the API key appended as a query parameter.
+        Generate a URL with the API key appended as a ``k`` query parameter.
+
+        Merges the key with any existing query parameters.
 
         Parameters
         ----------
@@ -78,7 +80,11 @@ class RequestHelper:
         str
             The URL with the API key.
         """
-        return f"{url}{'&' if '?' in url else '?'}k={api_key}"
+        parsed_url = urllib.parse.urlparse(url)
+        query = urllib.parse.parse_qs(parsed_url.query)
+        query.update({"k": [api_key]})
+        new_query = urllib.parse.urlencode(query, doseq=True)
+        return urllib.parse.urlunparse(parsed_url._replace(query=new_query))
 
     # -------- Public Request Methods --------
     @staticmethod


### PR DESCRIPTION
## Summary
- refactor `generate_url_with_key` to merge query parameters via `urllib.parse`

## Testing
- `pydocstyle PermutiveAPI`
- `pyright PermutiveAPI`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68972688e6d4832988dfe6429011ec5e