### PR TITLE
Fix CodeQL workflow permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze code with CodeQL


### PR DESCRIPTION
## Summary
- grant security-events permission for CodeQL upload

## Testing
- `pydocstyle PermutiveAPI` *(fails: command not found)*
- `pyright PermutiveAPI`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_689736e0ccb48329983bf476913fd293