### PR TITLE
Fix file existence check with platform-neutral glob

### DIFF
--- a/PermutiveAPI/Utils.py
+++ b/PermutiveAPI/Utils.py
@@ -451,7 +451,7 @@ class FileHelper:
         return file_path, file_name, file_extension
 
     @staticmethod
-    def file_exists(fullfilepath):
+    def file_exists(fullfilepath: str) -> bool:
         """Check if a file exists, accounting for variations in the filename.
 
         Parameters
@@ -467,9 +467,11 @@ class FileHelper:
         file_path, file_name, file_extension = FileHelper.split_filepath(
             fullfilepath)
 
-        if len(glob(f"{file_path}{file_name }-*{file_extension}") + glob(f"{file_path}{file_name}{file_extension}")) > 0:
-            return True
-        return False
+        pattern_with_suffix = os.path.join(
+            file_path, f"{file_name}-*{file_extension}"
+        )
+        pattern_exact = os.path.join(file_path, f"{file_name}{file_extension}")
+        return len(glob(pattern_with_suffix) + glob(pattern_exact)) > 0
 
 
 class ListHelper:


### PR DESCRIPTION
## Summary
- ensure FileHelper.file_exists builds glob patterns without stray whitespace
- use `os.path.join` for platform-neutral path construction and add type hints

## Testing
- `pydocstyle PermutiveAPI`
- `pyright PermutiveAPI`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68973ad13270832997bd671be06ad0de