### PR TITLE
Document subject entity level in Cohort docstring

### DIFF
--- a/PermutiveAPI/Cohort.py
+++ b/PermutiveAPI/Cohort.py
@@ -30,6 +30,8 @@ class Cohort(JSONSerializable):
         Tags associated with the cohort.
     description : Optional[str]
         A description of the cohort.
+    subject_entity_level : Optional[str]
+        The entity level for the cohort's subjects. Defaults to None.
     state : Optional[str]
         The state of the cohort.
     segment_type : Optional[str]


### PR DESCRIPTION
## Summary
- add subject_entity_level attribute to Cohort class docstring

## Testing
- `pydocstyle PermutiveAPI`
- `pyright PermutiveAPI`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68973ae1535c8329b9b44a1d4ad89b29