### PR TITLE
Fix CodeQL workflow permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze code with CodeQL


### PR DESCRIPTION
## Summary
- grant security-events permission for CodeQL upload
- add actions permission for CodeQL workflow

## Testing
- `pydocstyle PermutiveAPI`
- `pyright PermutiveAPI`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689736e0ccb48329983bf476913fd293