### PR TITLE
Reset ImportList caches when rebuilding

### DIFF
--- a/PermutiveAPI/Import.py
+++ b/PermutiveAPI/Import.py
@@ -136,6 +136,9 @@ class ImportList(List[Import],
 
     def rebuild_cache(self):
         """Rebuild all caches based on the current state of the list."""
+        self._id_dictionary_cache = {}
+        self._name_dictionary_cache = {}
+        self._identifier_dictionary_cache = defaultdict(ImportList)
         for _import in self:
             self._id_dictionary_cache[_import.id] = _import
             self._name_dictionary_cache[_import.name] = _import

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -94,6 +94,21 @@ class TestImportList(unittest.TestCase):
         self.assertEqual(len(self.import_list.identifier_dictionary["id1"]), 2)
         self.assertEqual(len(self.import_list.identifier_dictionary["id2"]), 2)
 
+    def test_rebuild_cache_after_mutation(self):
+        new_import = Import(id="imp4", name="Import 4", code="I4", relation="r4", identifiers=["id2"], source=Source(id="src-1", state={}, type="type"))
+        self.import_list.append(new_import)
+        self.import_list.pop(0)
+        self.import_list.rebuild_cache()
+        self.assertNotIn("imp1", self.import_list.id_dictionary)
+        self.assertIn("imp4", self.import_list.id_dictionary)
+        self.assertNotIn("Import 1", self.import_list.name_dictionary)
+        self.assertIn("Import 4", self.import_list.name_dictionary)
+        self.assertEqual(len(self.import_list.identifier_dictionary["id1"]), 1)
+        self.assertEqual(self.import_list.identifier_dictionary["id1"][0].id, "imp2")
+        id2_ids = [imp.id for imp in self.import_list.identifier_dictionary["id2"]]
+        self.assertEqual(len(id2_ids), len(set(id2_ids)))
+        self.assertCountEqual(id2_ids, ["imp2", "imp3", "imp4"])
+
 class TestSegment(unittest.TestCase):
     def setUp(self):
         self.api_key = "test_api_key"


### PR DESCRIPTION
## Summary
- Reset ImportList caches before rebuilding to prevent duplicate entries
- Add test ensuring cache rebuild reflects mutations without duplicates

## Testing
- `pydocstyle PermutiveAPI`
- `pyright PermutiveAPI`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68974b23f54c83298106ea3fd1fb9d7e