### PR TITLE
Fix Segment delete log formatting

### DIFF
--- a/PermutiveAPI/Segment.py
+++ b/PermutiveAPI/Segment.py
@@ -119,7 +119,7 @@ class Segment(JSONSerializable):
             204), otherwise ``False``.
         """
         logging.debug(
-            f"SegmentAPI::delete_segment::{self.import_id:}::{self.id}")
+            f"SegmentAPI::delete_segment::{self.import_id}::{self.id}")
         url = f"{_API_ENDPOINT}/{self.import_id}/segments/{self.id}"
         response = RequestHelper.delete_static(api_key=api_key,
                                                url=url)

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -162,6 +162,21 @@ class TestSegment(unittest.TestCase):
         mock_delete.assert_called_once()
         self.assertTrue(result)
 
+    @patch('PermutiveAPI.Segment.RequestHelper.delete_static')
+    def test_delete_logs_import_id(self, mock_delete):
+        # Arrange
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+        mock_delete.return_value = mock_response
+
+        with patch('PermutiveAPI.Segment.logging.debug') as mock_log:
+            # Act
+            self.segment.delete(self.api_key)
+
+            # Assert
+            mock_log.assert_called_with(
+                'SegmentAPI::delete_segment::import-123::seg-123')
+
     @patch('PermutiveAPI.Segment.RequestHelper.get_static')
     def test_get_by_code(self, mock_get):
         # Arrange


### PR DESCRIPTION
## Summary
- remove stray colon from Segment delete log message
- test delete log formatting for import ID

## Testing
- `pydocstyle PermutiveAPI`
- `pyright PermutiveAPI`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68974e57a1a48329b21703ed8869de59