### PR TITLE
Use UTC-aware timestamps

### DIFF
--- a/PermutiveAPI/Cohort.py
+++ b/PermutiveAPI/Cohort.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Dict, List, Optional, Union
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from PermutiveAPI.Utils import RequestHelper, JSONSerializable
 from collections import defaultdict
 
@@ -60,8 +60,12 @@ class Cohort(JSONSerializable):
     state: Optional[str] = None
     segment_type: Optional[str] = None
     live_audience_size: Optional[int] = 0
-    created_at: Optional[datetime] = field(default_factory=datetime.now)
-    last_updated_at: Optional[datetime] = field(default_factory=datetime.now)
+    created_at: Optional[datetime] = field(
+        default_factory=lambda: datetime.now(tz=timezone.utc)
+    )
+    last_updated_at: Optional[datetime] = field(
+        default_factory=lambda: datetime.now(tz=timezone.utc)
+    )
     workspace_id: Optional[str] = None
     request_id: Optional[str] = None
     error: Optional[str] = None

--- a/PermutiveAPI/Import.py
+++ b/PermutiveAPI/Import.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 
 if TYPE_CHECKING:
     from PermutiveAPI.Segment import SegmentList
-from datetime import datetime
+from datetime import datetime, timezone
 from collections import defaultdict
 
 from PermutiveAPI.Utils import RequestHelper, JSONSerializable
@@ -54,7 +54,9 @@ class Import(JSONSerializable):
     description: Optional[str] = None
     inheritance: Optional[str] = None
     segments: Optional['SegmentList'] = None
-    updated_at: Optional[datetime] = field(default_factory=datetime.now)
+    updated_at: Optional[datetime] = field(
+        default_factory=lambda: datetime.now(tz=timezone.utc)
+    )
 
     @classmethod
     def get_by_id(cls,

--- a/PermutiveAPI/Segment.py
+++ b/PermutiveAPI/Segment.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Dict, List, Optional
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 
 from PermutiveAPI.Utils import RequestHelper, JSONSerializable
 
@@ -44,7 +44,9 @@ class Segment(JSONSerializable):
     description: Optional[str] = None
     cpm: Optional[float] = 0.0
     categories: Optional[List[str]] = None
-    updated_at: Optional[datetime] = field(default_factory=datetime.now)
+    updated_at: Optional[datetime] = field(
+        default_factory=lambda: datetime.now(tz=timezone.utc)
+    )
 
     def create(self,
                api_key: str):

--- a/tests/test_cohort.py
+++ b/tests/test_cohort.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 import unittest
 from unittest.mock import patch, MagicMock
+from datetime import timezone
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -20,6 +21,13 @@ class TestCohort(unittest.TestCase):
             "code": "C123"
         }
         self.cohort = Cohort(**self.cohort_data)
+
+    def test_default_datetime_timezone(self):
+        cohort = Cohort(name="T", query={"type": "and", "conditions": []})
+        self.assertIsNotNone(cohort.created_at)
+        self.assertIsNotNone(cohort.last_updated_at)
+        self.assertEqual(cohort.created_at.tzinfo, timezone.utc)
+        self.assertEqual(cohort.last_updated_at.tzinfo, timezone.utc)
 
     @patch('PermutiveAPI.Cohort.RequestHelper.post_static')
     def test_create_cohort(self, mock_post):

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -2,7 +2,7 @@ import sys
 from pathlib import Path
 import unittest
 from unittest.mock import patch, MagicMock
-from datetime import datetime
+from datetime import timezone
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -67,6 +67,12 @@ class TestImport(unittest.TestCase):
         self.assertIsInstance(results, list)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].id, "import-123")
+
+    def test_default_updated_at_timezone(self):
+        source = Source(**self.source_data)
+        imp = Import(id="imp", name="N", code="C", relation="r", identifiers=[], source=source)
+        self.assertIsNotNone(imp.updated_at)
+        self.assertEqual(imp.updated_at.tzinfo, timezone.utc)
 
 class TestImportList(unittest.TestCase):
     def setUp(self):
@@ -219,6 +225,11 @@ class TestSegment(unittest.TestCase):
         mock_get.assert_called_once()
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].id, "seg-123")
+
+    def test_default_updated_at_timezone(self):
+        seg = Segment(import_id="import-123", name="Test Segment", code="S123")
+        self.assertIsNotNone(seg.updated_at)
+        self.assertEqual(seg.updated_at.tzinfo, timezone.utc)
 
 class TestSegmentList(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- ensure Import, Segment, and Cohort timestamps use UTC-aware datetimes
- verify default timestamp timezone in associated tests

## Testing
- `pydocstyle PermutiveAPI`
- `pyright PermutiveAPI`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68974f92257083299c426a8326f98f31