### PR TITLE
I've fixed the return type hint for the `from_json` method for list-l…

### DIFF
--- a/PermutiveAPI/Cohort.py
+++ b/PermutiveAPI/Cohort.py
@@ -274,6 +274,10 @@ class Cohort(JSONSerializable):
         return cohort_list
 
 
+from pathlib import Path
+from typing import Any, overload, Type
+
+
 class CohortList(List[Cohort], JSONSerializable):
     """A list-like object for managing a collection of Cohort instances.
 
@@ -298,6 +302,32 @@ class CohortList(List[Cohort], JSONSerializable):
         self._segment_type_dictionary_cache: Dict[str, List[Cohort]] = defaultdict(
             list)
         self.rebuild_cache()
+
+    @overload
+    @classmethod
+    def from_json(cls: Type["CohortList"], data: dict) -> "CohortList": ...
+
+    @overload
+    @classmethod
+    def from_json(cls: Type["CohortList"],
+                  data: list[dict]) -> "CohortList": ...
+
+    @overload
+    @classmethod
+    def from_json(cls: Type["CohortList"], data: str) -> "CohortList": ...
+
+    @overload
+    @classmethod
+    def from_json(cls: Type["CohortList"], data: Path) -> "CohortList": ...
+
+    @classmethod
+    def from_json(cls: Type["CohortList"], data: Any) -> "CohortList":
+        """Deserialize workspace data from various JSON representations."""
+        result = super().from_json(data)
+        if isinstance(result, cls):
+            return result
+        # This should be dead code at runtime if my analysis is correct
+        raise TypeError(f"Expected {cls.__name__}, got {type(result).__name__}")
 
     def rebuild_cache(self):
         """Rebuild all caches based on the current state of the list.

--- a/PermutiveAPI/Import.py
+++ b/PermutiveAPI/Import.py
@@ -117,6 +117,10 @@ class Import(JSONSerializable):
         return ImportList([create_import(item) for item in imports['items']])
 
 
+from pathlib import Path
+from typing import Any, overload, Type
+
+
 class ImportList(List[Import],
                  JSONSerializable):
     """A class representing a list of Import objects with additional functionality for caching and serialization."""
@@ -135,6 +139,32 @@ class ImportList(List[Import],
         self._identifier_dictionary_cache: DefaultDict[str, ImportList] = defaultdict(
             ImportList)
         self.rebuild_cache()
+
+    @overload
+    @classmethod
+    def from_json(cls: Type["ImportList"], data: dict) -> "ImportList": ...
+
+    @overload
+    @classmethod
+    def from_json(cls: Type["ImportList"],
+                  data: list[dict]) -> "ImportList": ...
+
+    @overload
+    @classmethod
+    def from_json(cls: Type["ImportList"], data: str) -> "ImportList": ...
+
+    @overload
+    @classmethod
+    def from_json(cls: Type["ImportList"], data: Path) -> "ImportList": ...
+
+    @classmethod
+    def from_json(cls: Type["ImportList"], data: Any) -> "ImportList":
+        """Deserialize workspace data from various JSON representations."""
+        result = super().from_json(data)
+        if isinstance(result, cls):
+            return result
+        # This should be dead code at runtime if my analysis is correct
+        raise TypeError(f"Expected {cls.__name__}, got {type(result).__name__}")
 
     def rebuild_cache(self):
         """Rebuild all caches based on the current state of the list."""

--- a/PermutiveAPI/Workspace.py
+++ b/PermutiveAPI/Workspace.py
@@ -144,6 +144,32 @@ class WorkspaceList(List[Workspace], JSONSerializable):
         self._name_dictionary_cache: Dict[str, Workspace] = {}
         self.rebuild_cache()
 
+    @overload
+    @classmethod
+    def from_json(cls: Type["WorkspaceList"], data: dict) -> "WorkspaceList": ...
+
+    @overload
+    @classmethod
+    def from_json(cls: Type["WorkspaceList"],
+                  data: list[dict]) -> "WorkspaceList": ...
+
+    @overload
+    @classmethod
+    def from_json(cls: Type["WorkspaceList"], data: str) -> "WorkspaceList": ...
+
+    @overload
+    @classmethod
+    def from_json(cls: Type["WorkspaceList"], data: Path) -> "WorkspaceList": ...
+
+    @classmethod
+    def from_json(cls: Type["WorkspaceList"], data: Any) -> "WorkspaceList":
+        """Deserialize workspace data from various JSON representations."""
+        result = super().from_json(data)
+        if isinstance(result, cls):
+            return result
+        # This should be dead code at runtime if my analysis is correct
+        raise TypeError(f"Expected {cls.__name__}, got {type(result).__name__}")
+
     def rebuild_cache(self):
         """Rebuild all caches based on the current state of the list."""
         self._id_dictionary_cache = {


### PR DESCRIPTION
…ike classes.

I found that the `JSONSerializable.from_json` method had a return type annotation of `Union[T, List[T]]`. This was causing incorrect type inference for list-like subclasses (e.g., `WorkspaceList`), where `T` would be `WorkspaceList`, leading to a return type of `Union[WorkspaceList, List[WorkspaceList]]`. As a result, Pylance was raising a `reportArgumentType` error where this method was used.

To resolve this, I overrode the `from_json` method in the affected list-like classes (`WorkspaceList`, `CohortList`, `ImportList`). The overriding methods now provide a more specific return type annotation (`-> T`), which correctly reflects the runtime behavior and satisfies the static type checker.

Here are the specific changes I made:
- Added an overriding `from_json` method with specific overloads to `WorkspaceList` in `PermutiveAPI/Workspace.py`.
- Added an overriding `from_json` method with specific overloads to `CohortList` in `PermutiveAPI/Cohort.py`.
- Added an overriding `from_json` method with specific overloads to `ImportList` in `PermutiveAPI/Import.py`.