### PR TITLE
Refactor from_json to be stricter and improve type safety

### DIFF
--- a/PermutiveAPI/Cohort.py
+++ b/PermutiveAPI/Cohort.py
@@ -269,9 +269,12 @@ class Cohort(JSONSerializable):
         response = RequestHelper.get_static(api_key, url)
         if response is None:
             raise ValueError("Response is None")
-        cohort_list = CohortList([Cohort(**cohort)
-                                 for cohort in response.json()])
-        return cohort_list
+        return CohortList.from_json(response.json())
+
+
+import json
+from pathlib import Path
+from typing import Type, Union
 
 
 class CohortList(List[Cohort], JSONSerializable):
@@ -279,6 +282,28 @@ class CohortList(List[Cohort], JSONSerializable):
 
     It provides caching mechanisms for quick lookups by id, code, name, etc.
     """
+    @classmethod
+    def from_json(
+        cls: Type["CohortList"],
+        data: Union[list[dict], str, Path],
+    ) -> "CohortList":
+        """Deserialize a list of cohorts from various JSON representations."""
+        if isinstance(data, (str, Path)):
+            try:
+                if isinstance(data, Path):
+                    content = data.read_text(encoding="utf-8")
+                else:
+                    content = data
+                data = json.loads(content)
+            except Exception as e:
+                raise TypeError(f"Failed to parse JSON from input: {e}")
+
+        if isinstance(data, list):
+            return cls([Cohort.from_json(item) for item in data])
+
+        raise TypeError(
+            f"`from_json()` expected a list of dicts, JSON string, or Path, but got {type(data).__name__}"
+        )
 
     def __init__(self, items_list: Optional[List[Cohort]] = None):
         """Initialize the CohortList.

--- a/PermutiveAPI/Import.py
+++ b/PermutiveAPI/Import.py
@@ -106,20 +106,46 @@ class Import(JSONSerializable):
         if response is None:
             raise ValueError("Response is None")
         imports = response.json()
+        return ImportList.from_json(imports['items'])
 
-        def create_import(item):
-            source_data = item.get('source')
-            if source_data:
-                source_instance = Source.from_json(source_data)
-                item['source'] = source_instance
-            return cls(**item)
 
-        return ImportList([create_import(item) for item in imports['items']])
+import json
+from pathlib import Path
+from typing import Type, Union
 
 
 class ImportList(List[Import],
                  JSONSerializable):
     """A class representing a list of Import objects with additional functionality for caching and serialization."""
+    @classmethod
+    def from_json(
+        cls: Type["ImportList"],
+        data: Union[list[dict], str, Path],
+    ) -> "ImportList":
+        """Deserialize a list of imports from various JSON representations."""
+        if isinstance(data, (str, Path)):
+            try:
+                if isinstance(data, Path):
+                    content = data.read_text(encoding="utf-8")
+                else:
+                    content = data
+                data = json.loads(content)
+            except Exception as e:
+                raise TypeError(f"Failed to parse JSON from input: {e}")
+
+        if isinstance(data, list):
+            # Special handling for 'source' which is a nested JSONSerializable
+            def create_import(item):
+                source_data = item.get('source')
+                if source_data:
+                    source_instance = Source.from_json(source_data)
+                    item['source'] = source_instance
+                return Import.from_json(item)
+            return cls([create_import(item) for item in data])
+
+        raise TypeError(
+            f"`from_json()` expected a list of dicts, JSON string, or Path, but got {type(data).__name__}"
+        )
 
     def __init__(self, items_list: Optional[List[Import]] = None):
         """Initialize the ImportList with optional items.

--- a/PermutiveAPI/Utils.py
+++ b/PermutiveAPI/Utils.py
@@ -684,19 +684,15 @@ class JSONSerializable:
 
     @overload
     @classmethod
-    def from_json(cls: Type[T], data: list[dict]) -> list[T]: ...
+    def from_json(cls: Type[T], data: str) -> T: ...
 
     @overload
     @classmethod
-    def from_json(cls: Type[T], data: str) -> Union[T, List[T]]: ...
-
-    @overload
-    @classmethod
-    def from_json(cls: Type[T], data: Path) -> Union[T, List[T]]: ...
+    def from_json(cls: Type[T], data: Path) -> T: ...
 
     @classmethod
-    def from_json(cls: Type[T], data: Any) -> Union[T, List[T]]:
-        """Handle JSON deserialization from dict, list[dict], JSON string, or file path."""
+    def from_json(cls: Type[T], data: Any) -> T:
+        """Handle JSON deserialization from dict, JSON string, or file path."""
         # Load if input is a string or path
         if isinstance(data, (str, Path)):
             try:
@@ -708,28 +704,10 @@ class JSONSerializable:
             except Exception as e:
                 raise TypeError(f"Failed to parse JSON from input: {e}")
 
-        # If list of dicts and cls is a list subclass
-        if isinstance(data, list):
-            if issubclass(cls, list):
-                try:
-                    # type: ignore[attr-defined]
-                    base_args = get_args(cls.__orig_bases__[0])  # type: ignore
-                    if not base_args:
-                        raise TypeError(
-                            "Cannot determine list item type for deserialization")
-                    item_type = base_args[0]
-                except Exception as e:
-                    raise TypeError(
-                        f"Failed to resolve list item type for {cls.__name__}: {e}")
-                # type: ignore
-                return cls([item_type.from_json(item) for item in data])
-            else:
-                return [cls.from_json(item) for item in data]
-
         # Single dict
         if isinstance(data, dict):
             return cls(**data)
 
         raise TypeError(
-            f"`from_json()` expected a dict, list of dicts, JSON string, or Path, but got {type(data).__name__}"
+            f"`from_json()` expected a dict, JSON string, or Path, but got {type(data).__name__}"
         )


### PR DESCRIPTION
I refactored the `from_json` deserialization logic to be stricter and more explicit. The previous implementation had a generic `from_json` method that could return either a single object or a list of objects, which caused type ambiguity.

The new design enforces a clear separation of concerns:
- `SomeClass.from_json` is now responsible for deserializing only a single JSON object into an instance of `SomeClass`. The method signature has been simplified to return only `T`.
- `SomeClassList.from_json` is a new method responsible for deserializing a list of JSON objects into an instance of `SomeClassList`.

This refactoring provides several benefits:
- **Improved Type Safety**: Removes the `Union[T, List[T]]` return type, resolving the Pylance `reportArgumentType` error in a more fundamental way.
- **API Clarity**: The API is now more explicit and predictable. It's clear which method to use for single objects versus lists.
- **Simplified Code**: The base `JSONSerializable.from_json` method is now much simpler.

Changes include:
- Simplified `JSONSerializable.from_json` to only handle single objects.
- Removed list-handling overloads from `Workspace.from_json`.
- Implemented `from_json` on `WorkspaceList`, `CohortList`, and `ImportList` to handle list deserialization.
- Updated the `.list()` methods in `Cohort.py` and `Import.py` to use the new `...List.from_json` methods.