### PR TITLE
Fix from_json overloads causing NameError

### DIFF
--- a/PermutiveAPI/Cohort.py
+++ b/PermutiveAPI/Cohort.py
@@ -274,6 +274,7 @@ class CohortList(List[Cohort], JSONSerializable):
 
     It provides caching mechanisms for quick lookups by id, code, name, etc.
     """
+
     @classmethod
     def from_json(
         cls: Type["CohortList"],
@@ -320,32 +321,6 @@ class CohortList(List[Cohort], JSONSerializable):
         self._segment_type_dictionary_cache: Dict[str, List[Cohort]] = defaultdict(
             list)
         self.rebuild_cache()
-
-    @overload
-    @classmethod
-    def from_json(cls: Type["CohortList"], data: dict) -> "CohortList": ...
-
-    @overload
-    @classmethod
-    def from_json(cls: Type["CohortList"],
-                  data: list[dict]) -> "CohortList": ...
-
-    @overload
-    @classmethod
-    def from_json(cls: Type["CohortList"], data: str) -> "CohortList": ...
-
-    @overload
-    @classmethod
-    def from_json(cls: Type["CohortList"], data: Path) -> "CohortList": ...
-
-    @classmethod
-    def from_json(cls: Type["CohortList"], data: Any) -> "CohortList":
-        """Deserialize workspace data from various JSON representations."""
-        result = super().from_json(data)
-        if isinstance(result, cls):
-            return result
-        # This should be dead code at runtime if my analysis is correct
-        raise TypeError(f"Expected {cls.__name__}, got {type(result).__name__}")
 
     def rebuild_cache(self):
         """Rebuild all caches based on the current state of the list.

--- a/PermutiveAPI/Import.py
+++ b/PermutiveAPI/Import.py
@@ -114,6 +114,7 @@ class Import(JSONSerializable):
 class ImportList(List[Import],
                  JSONSerializable):
     """A class representing a list of Import objects with additional functionality for caching and serialization."""
+
     @classmethod
     def from_json(
         cls: Type["ImportList"],
@@ -163,32 +164,6 @@ class ImportList(List[Import],
         self._identifier_dictionary_cache: DefaultDict[str, ImportList] = defaultdict(
             ImportList)
         self.rebuild_cache()
-
-    @overload
-    @classmethod
-    def from_json(cls: Type["ImportList"], data: dict) -> "ImportList": ...
-
-    @overload
-    @classmethod
-    def from_json(cls: Type["ImportList"],
-                  data: list[dict]) -> "ImportList": ...
-
-    @overload
-    @classmethod
-    def from_json(cls: Type["ImportList"], data: str) -> "ImportList": ...
-
-    @overload
-    @classmethod
-    def from_json(cls: Type["ImportList"], data: Path) -> "ImportList": ...
-
-    @classmethod
-    def from_json(cls: Type["ImportList"], data: Any) -> "ImportList":
-        """Deserialize workspace data from various JSON representations."""
-        result = super().from_json(data)
-        if isinstance(result, cls):
-            return result
-        # This should be dead code at runtime if my analysis is correct
-        raise TypeError(f"Expected {cls.__name__}, got {type(result).__name__}")
 
     def rebuild_cache(self):
         """Rebuild all caches based on the current state of the list."""

--- a/PermutiveAPI/Segment.py
+++ b/PermutiveAPI/Segment.py
@@ -250,6 +250,7 @@ class Segment(JSONSerializable):
 class SegmentList(List[Segment],
                   JSONSerializable):
     """Custom list that holds Segment objects and provides caching and serialization."""
+
     @classmethod
     def from_json(
         cls: Type["SegmentList"],

--- a/PermutiveAPI/Workspace.py
+++ b/PermutiveAPI/Workspace.py
@@ -1,7 +1,7 @@
 """Workspace utilities for interacting with the Permutive API."""
 
 import json
-from typing import Dict, List, Optional, Any, overload, Type, Union
+from typing import Dict, List, Optional, Type, Union
 from dataclasses import dataclass
 from pathlib import Path
 from PermutiveAPI.Utils import JSONSerializable
@@ -105,6 +105,7 @@ class Workspace(JSONSerializable):
 
 class WorkspaceList(List[Workspace], JSONSerializable):
     """Manage a collection of Workspace objects."""
+
     @classmethod
     def from_json(
         cls: Type["WorkspaceList"],
@@ -146,32 +147,6 @@ class WorkspaceList(List[Workspace], JSONSerializable):
         self._id_dictionary_cache: Dict[str, Workspace] = {}
         self._name_dictionary_cache: Dict[str, Workspace] = {}
         self.rebuild_cache()
-
-    @overload
-    @classmethod
-    def from_json(cls: Type["WorkspaceList"], data: dict) -> "WorkspaceList": ...
-
-    @overload
-    @classmethod
-    def from_json(cls: Type["WorkspaceList"],
-                  data: list[dict]) -> "WorkspaceList": ...
-
-    @overload
-    @classmethod
-    def from_json(cls: Type["WorkspaceList"], data: str) -> "WorkspaceList": ...
-
-    @overload
-    @classmethod
-    def from_json(cls: Type["WorkspaceList"], data: Path) -> "WorkspaceList": ...
-
-    @classmethod
-    def from_json(cls: Type["WorkspaceList"], data: Any) -> "WorkspaceList":
-        """Deserialize workspace data from various JSON representations."""
-        result = super().from_json(data)
-        if isinstance(result, cls):
-            return result
-        # This should be dead code at runtime if my analysis is correct
-        raise TypeError(f"Expected {cls.__name__}, got {type(result).__name__}")
 
     def rebuild_cache(self):
         """Rebuild all caches based on the current state of the list."""


### PR DESCRIPTION
## Summary
- remove redundant from_json overloads in list classes
- tidy imports and docstring spacing

## Testing
- `pydocstyle PermutiveAPI`
- `pyright PermutiveAPI`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897b537a59c8329b0404215158d55db