### PR TITLE
Preserve falsey values in RequestHelper payloads

### DIFF
--- a/PermutiveAPI/Audience/__init__.py
+++ b/PermutiveAPI/Audience/__init__.py
@@ -1,2 +1,4 @@
+"""Configuration for the Audience API."""
+
 _API_VERSION = "v1"
 _API_ENDPOINT = f'https://api.permutive.app/audience-api/{_API_VERSION}/imports'

--- a/PermutiveAPI/Identify/__init__.py
+++ b/PermutiveAPI/Identify/__init__.py
@@ -1,2 +1,4 @@
+"""Configuration for the Identify API."""
+
 _API_VERSION = 'v2.0'
 _API_ENDPOINT = f'https://api.permutive.com/{_API_VERSION}/identify'

--- a/PermutiveAPI/Utils.py
+++ b/PermutiveAPI/Utils.py
@@ -254,6 +254,9 @@ class RequestHelper:
         """
         Convert a dataclass object to a dictionary payload.
 
+        Fields with ``None`` values are omitted. If ``api_payload`` is provided,
+        only keys included in this list are kept.
+
         Parameters
         ----------
         dataclass_obj : Any
@@ -267,8 +270,11 @@ class RequestHelper:
             The dictionary payload.
         """
         dataclass_dict = vars(dataclass_obj)
-        filtered_dict = {k: v for k, v in dataclass_dict.items(
-        ) if v and (api_payload is None or k in api_payload)}
+        filtered_dict = {
+            k: v
+            for k, v in dataclass_dict.items()
+            if v is not None and (api_payload is None or k in api_payload)
+        }
         filtered_dict_string = json.dumps(
             filtered_dict, indent=4, cls=customJSONEncoder)
         return json.loads(filtered_dict_string)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,9 @@
 """Tests for helper utilities in :mod:`PermutiveAPI.Utils`."""
 
 import sys
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 import unittest
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
@@ -11,6 +13,15 @@ from requests.exceptions import RequestException
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from PermutiveAPI.Utils import RequestHelper, merge_list, split_filepath, file_exists
+
+
+@dataclass
+class PayloadExample:
+    """Dataclass for payload serialization tests."""
+
+    zero: int
+    flag: bool
+    none_val: Optional[str] = None
 
 
 class TestRequestHelper(unittest.TestCase):
@@ -38,6 +49,24 @@ class TestRequestHelper(unittest.TestCase):
             with self.assertRaises(RequestException):
                 RequestHelper.get_static("abc123", "https://api.example.com")
             self.assertEqual(mock_get.call_count, 2)
+
+    def test_to_payload_static_keeps_zero(self) -> None:
+        """Retain zero values in the serialized payload."""
+        payload = RequestHelper.to_payload_static(
+            PayloadExample(zero=0, flag=True)
+        )
+        self.assertIn("zero", payload)
+        self.assertEqual(payload["zero"], 0)
+        self.assertNotIn("none_val", payload)
+
+    def test_to_payload_static_keeps_false(self) -> None:
+        """Retain ``False`` boolean values in the serialized payload."""
+        payload = RequestHelper.to_payload_static(
+            PayloadExample(zero=1, flag=False)
+        )
+        self.assertIn("flag", payload)
+        self.assertIs(payload["flag"], False)
+        self.assertNotIn("none_val", payload)
 
 
 class TestListUtils(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Avoid dropping 0 and False values in `RequestHelper.to_payload_static`
- Test payload serialization of zero and False values
- Document package init modules for linter compliance

## Testing
- `pydocstyle PermutiveAPI`
- `pyright PermutiveAPI`
- `pytest tests/test_utils.py::TestRequestHelper`
- `pytest -q` *(fails: AttributeError: type object 'Import' has no attribute 'RequestHelper')*

------
https://chatgpt.com/codex/tasks/task_e_6897c01035e883298418cd0311fdc88f