### PR TITLE
Use SPDX license string in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,13 @@ version = "v5.2.0"
 description = "A Python wrapper for the Permutive API."
 readme = "README.md"
 authors = [{ name = "fatmambo33", email = "fatmambo33@gmail.com" }]
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.7"
 dependencies = ["requests", "python-dotenv"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
## Summary
- replace deprecated license table with SPDX string
- remove deprecated license classifier

## Testing
- `pydocstyle PermutiveAPI`
- `pyright PermutiveAPI`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899f4ebd2a88329b029507a4d2d880c