### PR TITLE
Docs: switch to src layout, update install/CI commands, and refine docstrings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for considering contributing to this project! The following guidelines
 
 1. **Clone the repository**
    ```sh
-   git clone https://github.com/yourusername/PermutiveAPI.git
+   git clone https://github.com/fatmambo33/PermutiveAPI.git
    cd PermutiveAPI
    ```
 2. **Create a virtual environment** (recommended)
@@ -16,7 +16,7 @@ Thank you for considering contributing to this project! The following guidelines
    ```
 3. **Install development dependencies**
    ```sh
-   pip install -r requirements-dev.txt
+   pip install -e ".[dev]"
    ```
 4. **Install the package in editable mode** (optional)
    ```sh
@@ -33,22 +33,22 @@ Before committing, please run the following checks to ensure code quality and co
   ```
 - **Docstring Style with pydocstyle:**
   ```sh
-  pydocstyle PermutiveAPI
+  pydocstyle src/PermutiveAPI
   ```
 - **Static Type Checking with pyright:**
   ```sh
-  pyright PermutiveAPI
+  pyright src/PermutiveAPI
   ```
 
 ## Running Tests
 
-This project uses `pytest` for testing. To run the test suite, navigate to the root directory of the project and run the following command:
+This project uses `pytest` for testing. To run the test suite with the same coverage threshold used in CI, navigate to the root directory of the project and run:
 
 ```sh
-pytest
+pytest -q --cov=src/PermutiveAPI --cov-report=term-missing --cov-fail-under=70
 ```
 
-This will automatically discover and run all tests within the `tests` directory. Please ensure all tests pass before submitting a pull request.
+This command automatically discovers tests in the `tests` directory. Please ensure it passes before submitting a pull request.
 
 ## Pull Request Process
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PermutiveAPI
-[![PyPI version](https://img.shields.io/pypi/v/openai-sdk-helpers.svg)](https://pypi.org/project/openai-sdk-helpers/)
-[![Python versions](https://img.shields.io/pypi/pyversions/openai-sdk-helpers.svg)](https://pypi.org/project/openai-sdk-helpers/)
+[![PyPI version](https://img.shields.io/pypi/v/PermutiveAPI.svg)](https://pypi.org/project/PermutiveAPI/)
+[![Python versions](https://img.shields.io/pypi/pyversions/PermutiveAPI.svg)](https://pypi.org/project/PermutiveAPI/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 PermutiveAPI is a Python module to interact with the Permutive API. It provides a set of classes and methods to manage users, imports, cohorts, and workspaces within the Permutive ecosystem.
@@ -295,7 +295,7 @@ across the API.
 High-volume workflows often rely on the ``batch_*`` helpers to run requests
 concurrently. Every helper accepts an optional ``progress_callback`` that is
 invoked after each request completes with a
-:class:`~PermutiveAPI._Utils.http.Progress` snapshot describing aggregate
+`PermutiveAPI.utils.http.Progress` snapshot describing aggregate
 throughput. The dataclass includes counters for completed requests, failure
 totals, elapsed time, and the estimated seconds required to process 1,000
 requests, making it straightforward to surface both reliability and latency
@@ -306,7 +306,7 @@ and error rates because the Permutive API enforces rate limits.
 
 ```python
 from PermutiveAPI import Cohort
-from PermutiveAPI._Utils.http import Progress
+from PermutiveAPI.utils.http import Progress
 
 
 def on_progress(progress: Progress) -> None:
@@ -339,7 +339,7 @@ The same callback shape is shared across helpers such as
 ``Identity.batch_identify`` and ``Segment.batch_create``, enabling reuse of
 progress reporting utilities that surface throughput, error counts, and
 latency projections. The helpers delegate to
-:func:`PermutiveAPI._Utils.http.process_batch`, so they automatically benefit
+`PermutiveAPI.utils.http.process_batch`, so they automatically benefit
 from the shared retry/backoff configuration used by the underlying request
 helpers. When the API responds with ``HTTP 429`` (rate limiting), the helper
 retries using the exponential backoff already built into the package before
@@ -357,7 +357,7 @@ touching application code:
   integer to cap concurrency or leave it unset to use Python's default
   heuristic.
 - ``PERMUTIVE_BATCH_TIMEOUT_SECONDS`` controls the default timeout applied to
-  each ``PermutiveAPI._Utils.http.BatchRequest``. Set it to a positive
+  each `PermutiveAPI.utils.http.BatchRequest`. Set it to a positive
   float (in seconds) to align the HTTP timeout with your infrastructure's
   expectations.
 
@@ -474,7 +474,7 @@ except PermutiveAPIError as e:
 To set up a development environment, install the development dependencies:
 
 ```sh
-pip install ".[dev]"
+pip install -e ".[dev]"
 ```
 
 ### Running Tests
@@ -483,18 +483,18 @@ Before committing any changes, please run the following checks to ensure code qu
 
 **Style Checks:**
 ```bash
-pydocstyle PermutiveAPI
+pydocstyle src/PermutiveAPI
 black --check .
 ```
 
 **Static Type Analysis:**
 ```bash
-pyright PermutiveAPI
+pyright src/PermutiveAPI
 ```
 
 **Unit Tests and Coverage:**
 ```bash
-pytest -q --cov=PermutiveAPI --cov-report=term-missing --cov-fail-under=70
+pytest -q --cov=src/PermutiveAPI --cov-report=term-missing --cov-fail-under=70
 ```
 
 All checks must pass before a pull request can be merged.

--- a/src/PermutiveAPI/audience/source.py
+++ b/src/PermutiveAPI/audience/source.py
@@ -8,7 +8,13 @@ from ..utils.json import JSONSerializable
 
 @dataclass
 class Source(JSONSerializable[Dict[str, Any]]):
-    """Represents a Source entity in the Permutive ecosystem.
+    """Represent a Source entity in the Permutive ecosystem.
+
+    Methods
+    -------
+    None
+        Instances expose dataclass-generated attributes and JSONSerializable
+        helpers.
 
     Parameters
     ----------

--- a/src/PermutiveAPI/identify/alias.py
+++ b/src/PermutiveAPI/identify/alias.py
@@ -7,7 +7,13 @@ from ..utils.json import JSONSerializable
 
 @dataclass
 class Alias(JSONSerializable[Dict[str, Any]]):
-    """Represents an Alias entity in the Permutive ecosystem.
+    """Represent an Alias entity in the Permutive ecosystem.
+
+    Methods
+    -------
+    None
+        Instances expose dataclass-generated attributes and JSONSerializable
+        helpers.
 
     Parameters
     ----------

--- a/src/PermutiveAPI/utils/http.py
+++ b/src/PermutiveAPI/utils/http.py
@@ -33,7 +33,12 @@ from .json import to_payload as _json_to_payload
 
 
 class PermutiveAPIError(Exception):
-    """Base exception class for all PermutiveAPI errors.
+    """Represent a base exception for PermutiveAPI errors.
+
+    Methods
+    -------
+    __init__(message, *, status=None, url=None, response=None)
+        Initialise the exception with optional HTTP request context.
 
     Parameters
     ----------
@@ -64,13 +69,25 @@ class PermutiveAPIError(Exception):
 
 
 class PermutiveAuthenticationError(PermutiveAPIError):
-    """Raised when authentication fails (HTTP 401 or 403)."""
+    """Represent an authentication failure (HTTP 401 or 403).
+
+    Methods
+    -------
+    __init__(message, *, status=None, url=None, response=None)
+        Inherit base exception initialisation with HTTP context.
+    """
 
     pass
 
 
 class PermutiveBadRequestError(PermutiveAPIError):
-    """Raised for client-side errors (HTTP 400)."""
+    """Represent a client-side bad request error (HTTP 400).
+
+    Methods
+    -------
+    __init__(message, *, status=None, url=None, response=None)
+        Initialise the bad request error with optional HTTP context.
+    """
 
     def __init__(
         self,
@@ -86,19 +103,37 @@ class PermutiveBadRequestError(PermutiveAPIError):
 
 
 class PermutiveResourceNotFoundError(PermutiveAPIError):
-    """Raised when a requested resource is not found (HTTP 404)."""
+    """Represent a missing resource error (HTTP 404).
+
+    Methods
+    -------
+    __init__(message, *, status=None, url=None, response=None)
+        Inherit base exception initialisation with HTTP context.
+    """
 
     pass
 
 
 class PermutiveRateLimitError(PermutiveAPIError):
-    """Raised when the API rate limit is exceeded (HTTP 429)."""
+    """Represent an API rate limit error (HTTP 429).
+
+    Methods
+    -------
+    __init__(message, *, status=None, url=None, response=None)
+        Inherit base exception initialisation with HTTP context.
+    """
 
     pass
 
 
 class PermutiveServerError(PermutiveAPIError):
-    """Raised for server-side errors (HTTP 5xx)."""
+    """Represent a server-side API error (HTTP 5xx).
+
+    Methods
+    -------
+    __init__(message, *, status=None, url=None, response=None)
+        Inherit base exception initialisation with HTTP context.
+    """
 
     pass
 
@@ -212,7 +247,12 @@ def _default_initial_delay() -> float:
 
 @dataclass
 class RetryConfig:
-    """Configuration for retry/backoff behaviour.
+    """Describe retry and backoff configuration.
+
+    Methods
+    -------
+    None
+        Instances provide dataclass-generated attribute access only.
 
     Parameters
     ----------
@@ -278,7 +318,12 @@ class BatchRequest:
 
 @dataclass(frozen=True)
 class Progress:
-    """Immutable snapshot describing batch processing progress.
+    """Describe an immutable snapshot of batch processing progress.
+
+    Methods
+    -------
+    None
+        Instances provide dataclass-generated attribute access only.
 
     Parameters
     ----------

--- a/src/PermutiveAPI/utils/json.py
+++ b/src/PermutiveAPI/utils/json.py
@@ -147,7 +147,7 @@ T = TypeVar("T", bound="JSONSerializable")
 JSONOutput = TypeVar("JSONOutput", Dict[str, Any], List[Any])
 
 
-def json_default(value: Any):
+def json_default(value: Any) -> Any:
     """Provide JSON serialization for complex data types.
 
     Parameters


### PR DESCRIPTION
### Motivation
- Align documentation and development instructions with the package layout under `src/PermutiveAPI` and the actual repository package name and remote URL.
- Make contributor setup and CI-style commands explicit and consistent with editable installs and coverage collection from the `src` package tree.
- Clarify a number of module-level docstrings and exception/dataclass descriptions for better developer readability.

### Description
- Update `CONTRIBUTING.md` and `README.md` to use the repository clone URL, change install commands to `pip install -e ".[dev]"`, and adjust lint/type/test commands to target `src/PermutiveAPI` instead of the top-level package directory.
- Replace README package badge targets with `PermutiveAPI` and update internal docs to reference `PermutiveAPI.utils` instead of `PermutiveAPI._Utils` in a few places.
- Improve several docstrings across the codebase (`audience/source.py`, `identify/alias.py`, `utils/http.py`, `utils/json.py`) by clarifying descriptions, adding brief `Methods` sections where helpful, and adding a return type annotation for `json_default`.
- Keep the changes non-functional: no runtime logic was altered, only documentation, typing annotations, and developer-facing instructions were modified.

### Testing
- Ran formatting and lint checks with `black .` and `pydocstyle src/PermutiveAPI`, which completed successfully.
- Ran static type checks with `pyright src/PermutiveAPI`, which completed successfully.
- Executed the unit test suite and coverage with `pytest -q --cov=src/PermutiveAPI --cov-report=term-missing --cov-fail-under=70`, and the tests passed under the specified coverage threshold.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acd0807dd08329b2b0dfdbc7a55793)