### PR TITLE
Add keyword extraction helper to Cohort

### DIFF
--- a/src/PermutiveAPI/cohort.py
+++ b/src/PermutiveAPI/cohort.py
@@ -160,7 +160,7 @@ class Cohort(JSONSerializable[Dict[str, Any]]):
 
             return keywords
 
-        return sorted(_extract(self.query))
+        return sorted(_extract(self.query), key=str.casefold)
 
     def create(self, api_key: str) -> None:
         """Create a new cohort in Permutive.

--- a/src/PermutiveAPI/cohort.py
+++ b/src/PermutiveAPI/cohort.py
@@ -132,11 +132,9 @@ class Cohort(JSONSerializable[Dict[str, Any]]):
     def extract_keywords(self) -> List[str]:
         """Extract unique keyword strings from the cohort query.
 
-        The method traverses ``self.query`` recursively. When ``self.query`` is
-        an object exposing ``to_json()`` or ``model_dump()``, the method uses
-        its serialized form before traversal. It collects string values under
-        ``"contains"`` and ``"list_contains"`` keys, then returns the unique
-        values sorted in case-insensitive ascending order.
+        The method traverses ``self.query`` recursively. It collects string
+        values under ``"contains"`` and ``"list_contains"`` keys, then returns
+        the unique values sorted in case-insensitive ascending order.
 
         Returns
         -------
@@ -162,16 +160,7 @@ class Cohort(JSONSerializable[Dict[str, Any]]):
 
             return keywords
 
-        query_payload: Any = self.query
-        to_json = getattr(query_payload, "to_json", None)
-        model_dump = getattr(query_payload, "model_dump", None)
-
-        if callable(to_json):
-            query_payload = to_json()
-        elif callable(model_dump):
-            query_payload = model_dump()
-
-        return sorted(_extract(query_payload), key=lambda value: (value.casefold(), value))
+        return sorted(_extract(self.query), key=lambda value: (value.casefold(), value))
 
     def create(self, api_key: str) -> None:
         """Create a new cohort in Permutive.

--- a/src/PermutiveAPI/cohort.py
+++ b/src/PermutiveAPI/cohort.py
@@ -69,8 +69,8 @@ class Cohort(JSONSerializable[Dict[str, Any]]):
 
     Methods
     -------
-    extract_keywords(obj)
-        Extract sorted unique keyword strings from nested objects.
+    extract_keywords()
+        Extract sorted unique keyword strings from the cohort query.
     create(api_key)
         Create a new cohort in Permutive.
     update(api_key)
@@ -128,42 +128,38 @@ class Cohort(JSONSerializable[Dict[str, Any]]):
         elif self.last_updated_at is None:
             self.last_updated_at = self.created_at
 
-    @staticmethod
-    def extract_keywords(obj: Any) -> List[str]:
-        """Extract unique keyword strings from a nested query-like object.
+    def extract_keywords(self) -> List[str]:
+        """Extract unique keyword strings from the cohort query.
 
-        The method traverses dictionaries and lists recursively. It collects
-        string values under ``"contains"`` and ``"list_contains"`` keys, then
-        returns the unique values sorted in ascending order.
-
-        Parameters
-        ----------
-        obj : Any
-            Nested object to inspect. Supported containers are dictionaries and
-            lists.
+        The method traverses ``self.query`` recursively. It collects string
+        values under ``"contains"`` and ``"list_contains"`` keys, then returns
+        the unique values sorted in ascending order.
 
         Returns
         -------
         List[str]
-            Sorted unique keywords discovered in the object.
+            Sorted unique keywords discovered in the cohort query.
         """
-        keywords = set()
 
-        if isinstance(obj, dict):
-            for key, value in obj.items():
-                if key in {"contains", "list_contains"}:
-                    if isinstance(value, str):
-                        keywords.add(value)
-                    elif isinstance(value, list):
-                        keywords.update(v for v in value if isinstance(v, str))
-                else:
-                    keywords.update(Cohort.extract_keywords(value))
+        def _extract(obj: Any) -> set[str]:
+            keywords: set[str] = set()
 
-        elif isinstance(obj, list):
-            for item in obj:
-                keywords.update(Cohort.extract_keywords(item))
+            if isinstance(obj, dict):
+                for key, value in obj.items():
+                    if key in {"contains", "list_contains"}:
+                        if isinstance(value, str):
+                            keywords.add(value)
+                        elif isinstance(value, list):
+                            keywords.update(v for v in value if isinstance(v, str))
+                    else:
+                        keywords.update(_extract(value))
+            elif isinstance(obj, list):
+                for item in obj:
+                    keywords.update(_extract(item))
 
-        return sorted(keywords)
+            return keywords
+
+        return sorted(_extract(self.query))
 
     def create(self, api_key: str) -> None:
         """Create a new cohort in Permutive.

--- a/src/PermutiveAPI/cohort.py
+++ b/src/PermutiveAPI/cohort.py
@@ -132,9 +132,11 @@ class Cohort(JSONSerializable[Dict[str, Any]]):
     def extract_keywords(self) -> List[str]:
         """Extract unique keyword strings from the cohort query.
 
-        The method traverses ``self.query`` recursively. It collects string
-        values under ``"contains"`` and ``"list_contains"`` keys, then returns
-        the unique values sorted in ascending order.
+        The method traverses ``self.query`` recursively. When ``self.query`` is
+        an object exposing ``to_json()`` or ``model_dump()``, the method uses
+        its serialized form before traversal. It collects string values under
+        ``"contains"`` and ``"list_contains"`` keys, then returns the unique
+        values sorted in case-insensitive ascending order.
 
         Returns
         -------
@@ -160,7 +162,16 @@ class Cohort(JSONSerializable[Dict[str, Any]]):
 
             return keywords
 
-        return sorted(_extract(self.query), key=str.casefold)
+        query_payload: Any = self.query
+        to_json = getattr(query_payload, "to_json", None)
+        model_dump = getattr(query_payload, "model_dump", None)
+
+        if callable(to_json):
+            query_payload = to_json()
+        elif callable(model_dump):
+            query_payload = model_dump()
+
+        return sorted(_extract(query_payload), key=lambda value: (value.casefold(), value))
 
     def create(self, api_key: str) -> None:
         """Create a new cohort in Permutive.

--- a/src/PermutiveAPI/cohort.py
+++ b/src/PermutiveAPI/cohort.py
@@ -69,6 +69,8 @@ class Cohort(JSONSerializable[Dict[str, Any]]):
 
     Methods
     -------
+    extract_keywords(obj)
+        Extract sorted unique keyword strings from nested objects.
     create(api_key)
         Create a new cohort in Permutive.
     update(api_key)
@@ -125,6 +127,43 @@ class Cohort(JSONSerializable[Dict[str, Any]]):
             self.created_at = self.last_updated_at
         elif self.last_updated_at is None:
             self.last_updated_at = self.created_at
+
+    @staticmethod
+    def extract_keywords(obj: Any) -> List[str]:
+        """Extract unique keyword strings from a nested query-like object.
+
+        The method traverses dictionaries and lists recursively. It collects
+        string values under ``"contains"`` and ``"list_contains"`` keys, then
+        returns the unique values sorted in ascending order.
+
+        Parameters
+        ----------
+        obj : Any
+            Nested object to inspect. Supported containers are dictionaries and
+            lists.
+
+        Returns
+        -------
+        List[str]
+            Sorted unique keywords discovered in the object.
+        """
+        keywords = set()
+
+        if isinstance(obj, dict):
+            for key, value in obj.items():
+                if key in {"contains", "list_contains"}:
+                    if isinstance(value, str):
+                        keywords.add(value)
+                    elif isinstance(value, list):
+                        keywords.update(v for v in value if isinstance(v, str))
+                else:
+                    keywords.update(Cohort.extract_keywords(value))
+
+        elif isinstance(obj, list):
+            for item in obj:
+                keywords.update(Cohort.extract_keywords(item))
+
+        return sorted(keywords)
 
     def create(self, api_key: str) -> None:
         """Create a new cohort in Permutive.

--- a/src/PermutiveAPI/cohort.py
+++ b/src/PermutiveAPI/cohort.py
@@ -12,6 +12,7 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Set,
     Tuple,
     Type,
     Union,
@@ -141,8 +142,8 @@ class Cohort(JSONSerializable[Dict[str, Any]]):
             Sorted unique keywords discovered in the cohort query.
         """
 
-        def _extract(obj: Any) -> set[str]:
-            keywords: set[str] = set()
+        def _extract(obj: Any) -> Set[str]:
+            keywords: Set[str] = set()
 
             if isinstance(obj, dict):
                 for key, value in obj.items():

--- a/tests/test_cohort.py
+++ b/tests/test_cohort.py
@@ -103,18 +103,6 @@ def test_extract_keywords():
     assert cohort.extract_keywords() == ["Alpha", "alpha", "finance", "news", "sports"]
 
 
-def test_extract_keywords_query_object():
-    """Test keyword extraction when query is a serializable query object."""
-
-    class Query:
-        def to_json(self):
-            return {"contains": "premium"}
-
-    cohort = Cohort(name="Query Object Cohort", query=Query())  # type: ignore[arg-type]
-
-    assert cohort.extract_keywords() == ["premium"]
-
-
 @patch.object(Cohort, "_request_helper")
 def test_cohort_create(mock_request_helper):
     """Test successful creation of a cohort."""

--- a/tests/test_cohort.py
+++ b/tests/test_cohort.py
@@ -87,7 +87,7 @@ def test_cohort_list_to_pd_dataframe():
 
 
 def test_extract_keywords():
-    """Test keyword extraction from nested query structures."""
+    """Test keyword extraction from a cohort query."""
     query = {
         "and": [
             {"contains": "sports"},
@@ -96,8 +96,9 @@ def test_extract_keywords():
             {"ignored": {"value": True}},
         ]
     }
+    cohort = Cohort(name="Keyword Cohort", query=query)
 
-    assert Cohort.extract_keywords(query) == ["finance", "news", "sports"]
+    assert cohort.extract_keywords() == ["finance", "news", "sports"]
 
 
 @patch.object(Cohort, "_request_helper")

--- a/tests/test_cohort.py
+++ b/tests/test_cohort.py
@@ -86,6 +86,20 @@ def test_cohort_list_to_pd_dataframe():
     assert "code" in df.columns
 
 
+def test_extract_keywords():
+    """Test keyword extraction from nested query structures."""
+    query = {
+        "and": [
+            {"contains": "sports"},
+            {"list_contains": ["finance", 42, "news"]},
+            {"nested": {"contains": "sports"}},
+            {"ignored": {"value": True}},
+        ]
+    }
+
+    assert Cohort.extract_keywords(query) == ["finance", "news", "sports"]
+
+
 @patch.object(Cohort, "_request_helper")
 def test_cohort_create(mock_request_helper):
     """Test successful creation of a cohort."""

--- a/tests/test_cohort.py
+++ b/tests/test_cohort.py
@@ -103,6 +103,18 @@ def test_extract_keywords():
     assert cohort.extract_keywords() == ["Alpha", "alpha", "finance", "news", "sports"]
 
 
+def test_extract_keywords_query_object():
+    """Test keyword extraction when query is a serializable query object."""
+
+    class Query:
+        def to_json(self):
+            return {"contains": "premium"}
+
+    cohort = Cohort(name="Query Object Cohort", query=Query())  # type: ignore[arg-type]
+
+    assert cohort.extract_keywords() == ["premium"]
+
+
 @patch.object(Cohort, "_request_helper")
 def test_cohort_create(mock_request_helper):
     """Test successful creation of a cohort."""

--- a/tests/test_cohort.py
+++ b/tests/test_cohort.py
@@ -93,12 +93,14 @@ def test_extract_keywords():
             {"contains": "sports"},
             {"list_contains": ["finance", 42, "news"]},
             {"nested": {"contains": "sports"}},
+            {"contains": "Alpha"},
+            {"contains": "alpha"},
             {"ignored": {"value": True}},
         ]
     }
     cohort = Cohort(name="Keyword Cohort", query=query)
 
-    assert cohort.extract_keywords() == ["finance", "news", "sports"]
+    assert cohort.extract_keywords() == ["Alpha", "alpha", "finance", "news", "sports"]
 
 
 @patch.object(Cohort, "_request_helper")


### PR DESCRIPTION
### Motivation
- Provide a utility on `Cohort` to extract string keywords from nested query-like objects (e.g. to inspect `contains` / `list_contains` entries) and return a deterministic, deduplicated list.

### Description
- Add `@staticmethod Cohort.extract_keywords(obj: Any) -> List[str]` which recursively traverses `dict` and `list` structures, collects string values under `"contains"` and `"list_contains"`, deduplicates them, and returns them sorted.
- Document the new helper in the `Cohort` class `Methods` section.
- Add `test_extract_keywords` in `tests/test_cohort.py` to validate nested traversal, filtering, deduplication, and sorted output.

### Testing
- Ran `pytest -q tests/test_cohort.py` and all cohort tests passed (`17 passed`).
- Ran `black --check src/PermutiveAPI/cohort.py tests/test_cohort.py` and formatting checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df4922c5a08329b5ac0dc1aa5e3447)