### PR TITLE
Ship first-class SDK baseline and bump to 6.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,42 +2,53 @@ name: Python CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 permissions:
   contents: read
 
 jobs:
-  build:
+  quality:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[dev]'
+      - name: Format
+        run: black --check src tests
+      - name: Docstrings
+        run: pydocstyle src/PermutiveAPI
+      - name: Types
+        run: pyright src/PermutiveAPI
+      - name: Tests
+        run: pytest -q --cov-fail-under=70
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e '.[dev]'
-
-    - name: Run style checks
-      run: |
-        pydocstyle PermutiveAPI
-        black --check .
-
-    - name: Run static type analysis
-      run: |
-        pyright .
-
-    - name: Run tests with coverage
-      run: |
-        pytest -q --cov=PermutiveAPI --cov-report=term-missing --cov-fail-under=70
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: python -m pip install --upgrade build twine
+      - run: python -m build
+      - run: python -m twine check dist/*
+      - name: Verify clean install
+        run: |
+          python -m venv /tmp/permutiveapi-venv
+          /tmp/permutiveapi-venv/bin/pip install dist/*.whl
+          /tmp/permutiveapi-venv/bin/python -c "import PermutiveAPI; print(PermutiveAPI.__all__)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to PermutiveAPI are documented here. The project follows Semantic Versioning.
+
+## 6.1.0 - 2026-08-04
+
+### Added
+- Explicit public SDK compatibility contract.
+- Strict package typing configuration and PEP 561 packaging declaration.
+- Python 3.13 validation.
+- Clean-wheel installation validation in CI.
+
+### Changed
+- Raised the supported Python floor to 3.9.
+- Made pandas an optional `dataframe` integration instead of a core dependency.
+- Normalized the package version to PEP 440 and advanced the minor version from 6.0.x to 6.1.0.
+- Updated GitHub Actions to current major versions.
+
+### Existing first-class capabilities audited
+- Shared reusable HTTP sessions and centralized request dispatch.
+- Explicit request timeouts.
+- Typed exception classes and secret redaction.
+- Bounded retries and `Retry-After` support.
+- Shared JSON serialization helpers.
+- Typed batch request and progress models.
+- Unit and integration-test separation.
+
+## Release policy
+
+- Patch releases contain backward-compatible fixes.
+- Minor releases contain backward-compatible features and deprecations.
+- Major releases may remove deprecated APIs or introduce breaking changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,37 +1,47 @@
 [project]
 name = "PermutiveAPI"
-version = "v6.0.1"
-description = "A Python wrapper for the Permutive API."
+version = "6.1.0"
+description = "A typed Python SDK for the Permutive API."
 readme = "README.md"
-authors = [{ name = "fatmambo33", email = "fatmambo33@gmail.com" }]
+authors = [{ name = "FaTmamBo33", email = "fatmambo33@gmail.com" }]
 license = { file = "LICENSE" }
-requires-python = ">=3.8"
-dependencies = ["requests", "python-dotenv", "pandas", "pydantic", "typing_extensions"]
+requires-python = ">=3.9"
+dependencies = [
+    "requests>=2.31",
+    "python-dotenv>=1.0",
+    "pydantic>=2",
+    "typing_extensions>=4.8; python_version < '3.11'",
+]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Typing :: Typed",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
 [project.optional-dependencies]
+dataframe = ["pandas>=2"]
 dev = [
-    "pydocstyle",
-    "pytest<9",
-    "pytest-pydocstyle",
-    "pyright",
-    "black",
-    "pytest-cov",
+    "black>=24",
+    "build>=1",
+    "pandas>=2",
+    "pydocstyle>=6",
+    "pyright>=1.1.390",
+    "pytest>=8,<9",
+    "pytest-cov>=5",
+    "pytest-pydocstyle>=2",
+    "twine>=5",
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.26"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build]
@@ -41,13 +51,29 @@ include = ["src/PermutiveAPI"]
 packages = ["src/PermutiveAPI"]
 
 [tool.hatch.build.targets.sdist]
-include = ["src/PermutiveAPI"]
+include = [
+    "src/PermutiveAPI",
+    "tests",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE",
+]
 
 [tool.pyright]
+include = ["src/PermutiveAPI"]
 extraPaths = ["src"]
+typeCheckingMode = "strict"
+reportMissingTypeStubs = false
+reportUnknownMemberType = false
+reportUnknownVariableType = false
+reportUnknownArgumentType = false
 
 [tool.pydocstyle]
 convention = "numpy"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+addopts = "--strict-markers --strict-config --cov=PermutiveAPI --cov-branch --cov-report=term-missing"
+markers = [
+    "integration: tests requiring live Permutive credentials",
+]


### PR DESCRIPTION
## Summary

Advances PermutiveAPI from 6.0.1 to **6.1.0** and establishes the packaging, typing, dependency, CI, and release baseline for the first-class SDK roadmap.

## Changes

- normalize the version to PEP 440 and bump one minor version to `6.1.0`;
- require Python 3.9+ and validate Python 3.9–3.13;
- declare the distribution as typed and enable strict Pyright analysis for package source;
- move pandas out of core dependencies into the `dataframe` extra;
- strengthen dependency minimums and development tooling;
- update CI actions and add clean wheel/sdist build and installation validation;
- add a changelog and semantic-versioning release policy.

## Roadmap coverage

This PR completes the release/packaging slice of #93, #102, and #103. The repository already contains centralized HTTP sessions, retry configuration, typed API exceptions, redaction, serialization utilities, batch request/progress models, and broad tests; subsequent commits/PRs will close remaining acceptance gaps rather than rewrite those existing foundations.

## Validation

CI must pass across all supported Python versions before merge.

Refs #91
Refs #93
Refs #94
Refs #95
Refs #96
Refs #97
Refs #98
Refs #99
Refs #100
Refs #101
Closes #102
Closes #103