### PR TITLE
Finalize PermutiveAPI 6.1.0 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 All notable changes to PermutiveAPI are documented here. The project follows Semantic Versioning.
 
-## 6.2.0 - 2026-08-04
+## 6.1.0 - 2026-08-04
 
 ### Added
+- Explicit public SDK compatibility contract.
 - Explicit synchronous `PermutiveClient` with dependency-injected transport and connect/read timeouts.
 - Stable typed JSON aliases and structured SDK exception hierarchy.
 - Bounded retry policy with safe-method defaults, `Retry-After`, jitter, and attempt metadata.
@@ -12,24 +13,15 @@ All notable changes to PermutiveAPI are documented here. The project follows Sem
 - Ordered bounded `BatchResult` execution with per-item errors, fail-fast mode, and progress callbacks.
 - Canonical typed `Resource[T]` CRUD/list facade.
 - Deterministic contract tests for transport, redaction, retry safety, pagination, and batch behavior.
-
-### Changed
-- Exported the new stable client primitives at package root while retaining legacy exports.
-- Enforced strict static analysis on the stable SDK surface.
-- Kept pandas behind the optional `dataframe` integration.
-- Enforced a 70% branch-aware coverage floor.
-- Advanced the minor version from 6.1.0 to 6.2.0.
-
-## 6.1.0 - 2026-08-04
-
-### Added
-- Explicit public SDK compatibility contract.
 - PEP 561 packaging declaration and Python 3.13 validation.
 - Clean-wheel installation validation in CI.
 
 ### Changed
+- Exported the new stable client primitives at package root while retaining legacy exports.
+- Enforced strict static analysis on the stable SDK surface.
 - Raised the supported Python floor to 3.9.
 - Made pandas an optional `dataframe` integration instead of a core dependency.
+- Enforced a 70% branch-aware coverage floor.
 - Normalized the package version to PEP 440 and advanced one minor version from 6.0.x to 6.1.0.
 - Updated GitHub Actions to current major versions.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PermutiveAPI"
-version = "6.2.0"
+version = "6.1.0"
 description = "A typed Python SDK for the Permutive API."
 readme = "README.md"
 authors = [{ name = "FaTmamBo33", email = "fatmambo33@gmail.com" }]


### PR DESCRIPTION
## Summary

Completes the roadmap release cleanup after PR #107.

- restores the package version to the requested `6.1.0`;
- consolidates the roadmap changes into the `6.1.0` changelog entry;
- removes the accidental duplicate `6.2.0` release metadata.

The implementation itself was validated and merged in #107.