### PR TITLE
Simplify the public SDK around resource namespaces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PermutiveAPI"
-version = "6.1.0"
+version = "6.2.0"
 description = "A typed Python SDK for the Permutive API."
 readme = "README.md"
 authors = [{ name = "FaTmamBo33", email = "fatmambo33@gmail.com" }]
@@ -67,6 +67,7 @@ line-length = 88
 [tool.pyright]
 include = [
     "src/PermutiveAPI/__init__.py",
+    "src/PermutiveAPI/client.py",
     "src/PermutiveAPI/resources.py",
     "src/PermutiveAPI/sdk.py",
 ]

--- a/src/PermutiveAPI/__init__.py
+++ b/src/PermutiveAPI/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
+from .client import PermutiveClient
 from .resources import Resource
 from .sdk import (
     AuthenticationError,
@@ -18,7 +19,6 @@ from .sdk import (
     JSONValue,
     NotFoundError,
     Page,
-    PermutiveClient,
     RateLimitError,
     RetryPolicy,
     SDKError,

--- a/src/PermutiveAPI/client.py
+++ b/src/PermutiveAPI/client.py
@@ -1,0 +1,49 @@
+"""Simple resource-oriented public client."""
+
+from __future__ import annotations
+
+from functools import cached_property
+
+from .resources import Resource
+from .sdk import JSONObject, PermutiveClient as TransportClient
+
+
+def _decode_object(payload: JSONObject) -> JSONObject:
+    """Return one decoded JSON object unchanged."""
+    return payload
+
+
+class PermutiveClient(TransportClient):
+    """Permutive client with one predictable entry point per resource.
+
+    Examples
+    --------
+    >>> client = PermutiveClient("api-key")
+    >>> cohort = client.cohorts.get("cohort-id")
+    >>> page = client.segments.list()
+    """
+
+    @cached_property
+    def cohorts(self) -> Resource[JSONObject]:
+        """Return cohort operations."""
+        return Resource(self, "cohorts-api/v2/cohorts", _decode_object)
+
+    @cached_property
+    def imports(self) -> Resource[JSONObject]:
+        """Return audience import operations."""
+        return Resource(self, "audiences-api/v1/imports", _decode_object)
+
+    @cached_property
+    def segments(self) -> Resource[JSONObject]:
+        """Return audience segment operations."""
+        return Resource(self, "audiences-api/v1/segments", _decode_object)
+
+    @cached_property
+    def sources(self) -> Resource[JSONObject]:
+        """Return audience source operations."""
+        return Resource(self, "audiences-api/v1/sources", _decode_object)
+
+    @cached_property
+    def workspaces(self) -> Resource[JSONObject]:
+        """Return workspace operations."""
+        return Resource(self, "workspaces-api/v1/workspaces", _decode_object)

--- a/src/PermutiveAPI/resources.py
+++ b/src/PermutiveAPI/resources.py
@@ -22,7 +22,7 @@ class Resource(Generic[T]):
         """Return one resource by identifier."""
         return self.decoder(self.client.request("GET", f"{self.path}/{resource_id}"))
 
-    def list_page(
+    def list(
         self, *, page_size: int = 100, continuation: Optional[str] = None
     ) -> Page[T]:
         """Return one typed page."""
@@ -32,6 +32,12 @@ class Resource(Generic[T]):
             page_size=page_size,
             continuation=continuation,
         )
+
+    def list_page(
+        self, *, page_size: int = 100, continuation: Optional[str] = None
+    ) -> Page[T]:
+        """Return one typed page using the compatibility method name."""
+        return self.list(page_size=page_size, continuation=continuation)
 
     def iter_all(
         self, *, page_size: int = 100, max_items: Optional[int] = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,48 @@
+"""Contract tests for the simplified public client."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from requests import Response
+
+from PermutiveAPI import PermutiveClient
+
+
+class FakeTransport:
+    """Deterministic transport for resource facade tests."""
+
+    def __init__(self, payloads: list[object]) -> None:
+        self.payloads = payloads
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    def request(self, method: str, url: str, **kwargs: Any) -> Response:
+        """Return the next configured response."""
+        self.calls.append((method, url, kwargs))
+        result = Response()
+        result.status_code = 200
+        result._content = json.dumps(self.payloads.pop(0)).encode()
+        return result
+
+
+def test_package_client_exposes_predictable_resource_namespaces() -> None:
+    """Expose one obvious operation surface for every primary resource."""
+    transport = FakeTransport([{"id": "one"}])
+    client = PermutiveClient("secret", transport=transport)
+
+    assert client.cohorts.get("one") == {"id": "one"}
+    assert transport.calls[0][0] == "GET"
+    assert transport.calls[0][1].endswith("/cohorts-api/v2/cohorts/one")
+    assert client.cohorts is client.cohorts
+
+
+def test_resource_list_uses_the_same_method_name_everywhere() -> None:
+    """List resources without exposing pagination implementation details."""
+    transport = FakeTransport([{"items": [{"id": "one"}]}])
+    client = PermutiveClient("secret", transport=transport)
+
+    page = client.segments.list(page_size=25)
+
+    assert page.items == ({"id": "one"},)
+    assert transport.calls[0][2]["params"]["limit"] == 25


### PR DESCRIPTION
## What changed

- add a package-root `PermutiveClient` with cached `cohorts`, `imports`, `segments`, `sources`, and `workspaces` namespaces;
- standardize resource operations around `get`, `list`, `create`, `update`, and `delete`;
- preserve `list_page` as a compatibility alias;
- keep low-level transport primitives available without making them the primary product surface;
- add deterministic contract tests for the simplified API;
- include the new client in strict Pyright validation;
- bump the minor version to `6.2.0`.

## Why

The SDK had strong transport primitives but still required users to understand low-level request and resource construction. This change creates one obvious entry point and one consistent mental model across primary Permutive resources.

## User impact

```python
from PermutiveAPI import PermutiveClient

client = PermutiveClient("api-key")
cohort = client.cohorts.get("cohort-id")
page = client.segments.list()
```

Existing legacy exports remain available.