### PR TITLE
Define the canonical public SDK surface

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -17,6 +17,11 @@ Build the best Python SDK for Permutive: simple, reliable, typed, and production
 - Public APIs are long-term commitments.
 - Documentation, tests, and types are part of every feature.
 
+## Public API
+
+`PUBLIC_API.md` is the source of truth for canonical, compatibility, deprecated, and internal SDK surfaces.
+New features must extend the canonical surface rather than introduce parallel entry points.
+
 ## Scope
 
 PermutiveAPI includes API clients, authentication, typed models, utilities, error handling, documentation, examples, and tests.

--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -1,0 +1,97 @@
+# Public API Contract
+
+PermutiveAPI exposes one canonical SDK surface and a temporary compatibility surface.
+This document is the source of truth for public support, deprecation, and removal decisions.
+
+## Canonical surface
+
+New code should use these exports from `PermutiveAPI`:
+
+### Client and resources
+
+- `PermutiveClient`
+- `Resource`
+
+### Typed SDK primitives
+
+- `JSONObject`
+- `JSONScalar`
+- `JSONValue`
+- `Page`
+- `RetryPolicy`
+- `BatchItem`
+- `BatchResult`
+- `execute_batch`
+
+### Canonical errors
+
+- `SDKError`
+- `AuthenticationError`
+- `AuthorizationError`
+- `ConflictError`
+- `DecodingError`
+- `NotFoundError`
+- `RateLimitError`
+- `ServerError`
+- `TransportError`
+- `ValidationError`
+
+The canonical surface is covered by compatibility tests and follows semantic versioning.
+Backward-compatible additions may ship in minor releases. Breaking changes require a major release.
+
+## Compatibility surface
+
+These legacy exports remain supported for existing users while resource operations are migrated to the canonical client:
+
+- `Alias`
+- `Cohort`
+- `CohortList`
+- `ContextSegment`
+- `Event`
+- `Identity`
+- `Import`
+- `ImportList`
+- `Segment`
+- `SegmentList`
+- `Segmentation`
+- `Source`
+- `Workspace`
+- `WorkspaceList`
+- `PermutiveAPIError`
+- `PermutiveAuthenticationError`
+- `PermutiveBadRequestError`
+- `PermutiveRateLimitError`
+- `PermutiveResourceNotFoundError`
+- `PermutiveServerError`
+
+Compatibility exports may be implemented as thin adapters, but must not define an independent transport contract.
+They will not be removed without a documented deprecation period and migration path.
+
+## Deprecated surface
+
+No package-root export is deprecated at this time.
+When an export becomes deprecated, the change must include:
+
+1. a runtime deprecation warning where practical;
+2. migration guidance;
+3. a changelog entry;
+4. the earliest major version in which removal may occur.
+
+## Internal surface
+
+Anything not listed in `PermutiveAPI.__all__` is internal unless a public document explicitly states otherwise.
+Internal modules, helpers, and implementation details may change without notice.
+Users must not rely on imports from private modules or names prefixed with `_`.
+
+## Decision rules
+
+- Prefer `PermutiveClient` and `Resource` for all new work.
+- Do not add a second way to perform the same operation without a documented product reason.
+- Public methods require stable names, typed signatures, documented errors, tests, and examples.
+- Compatibility code delegates to canonical code rather than duplicating request logic.
+- New package-root exports require an update to this document and the public API contract test.
+
+## Migration direction
+
+The roadmap is to move cohorts, imports, segments, workspaces, identity, segmentation, and context operations behind the canonical client and resource pattern while preserving documented compatibility entry points.
+Issue #113 tracks that implementation work.

--- a/tests/test_public_api_contract.py
+++ b/tests/test_public_api_contract.py
@@ -1,0 +1,70 @@
+"""Tests for the supported package-root API contract."""
+
+from __future__ import annotations
+
+import PermutiveAPI
+
+
+CANONICAL_EXPORTS = {
+    "AuthenticationError",
+    "AuthorizationError",
+    "BatchItem",
+    "BatchResult",
+    "ConflictError",
+    "DecodingError",
+    "JSONObject",
+    "JSONScalar",
+    "JSONValue",
+    "NotFoundError",
+    "Page",
+    "PermutiveClient",
+    "RateLimitError",
+    "Resource",
+    "RetryPolicy",
+    "SDKError",
+    "ServerError",
+    "TransportError",
+    "ValidationError",
+    "execute_batch",
+}
+
+COMPATIBILITY_EXPORTS = {
+    "Alias",
+    "Cohort",
+    "CohortList",
+    "ContextSegment",
+    "Event",
+    "Identity",
+    "Import",
+    "ImportList",
+    "PermutiveAPIError",
+    "PermutiveAuthenticationError",
+    "PermutiveBadRequestError",
+    "PermutiveRateLimitError",
+    "PermutiveResourceNotFoundError",
+    "PermutiveServerError",
+    "Segment",
+    "SegmentList",
+    "Segmentation",
+    "Source",
+    "Workspace",
+    "WorkspaceList",
+}
+
+
+def test_public_exports_are_fully_classified() -> None:
+    """Require every package-root export to have an explicit support class."""
+    classified = CANONICAL_EXPORTS | COMPATIBILITY_EXPORTS
+
+    assert set(PermutiveAPI.__all__) == classified
+
+
+def test_public_exports_are_available() -> None:
+    """Require every declared public export to resolve from the package root."""
+    for name in PermutiveAPI.__all__:
+        assert getattr(PermutiveAPI, name) is not None
+
+
+def test_public_export_names_are_unique() -> None:
+    """Keep the package-root contract deterministic and unambiguous."""
+    assert len(PermutiveAPI.__all__) == len(set(PermutiveAPI.__all__))


### PR DESCRIPTION
## Summary
- define canonical, compatibility, deprecated, and internal API classifications
- make `PUBLIC_API.md` the support contract for package-root exports
- add a contract test requiring every `PermutiveAPI.__all__` export to be classified and resolvable
- link the product vision to the public API contract

## Product impact
New development has one documented SDK direction: `PermutiveClient`, `Resource`, typed primitives, and structured SDK errors. Existing resource classes remain supported as compatibility exports until their migration in #113.

## Validation
- public export set is checked against the documented classification
- all declared exports must resolve from the package root
- duplicate public export names are rejected

Closes #112