### PR TITLE
feat: add Codex plugin and local credentials provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
+[project.entry-points."permutiveapi.plugins"]
+codex = "PermutiveAPI.plugins.codex:CodexPlugin"
+
 [project.optional-dependencies]
 dataframe = ["pandas>=2"]
 dev = [
@@ -72,7 +75,9 @@ line-length = 88
 include = [
     "src/PermutiveAPI/__init__.py",
     "src/PermutiveAPI/client.py",
+    "src/PermutiveAPI/credentials.py",
     "src/PermutiveAPI/models.py",
+    "src/PermutiveAPI/plugins",
     "src/PermutiveAPI/resources.py",
     "src/PermutiveAPI/sdk.py",
 ]

--- a/src/PermutiveAPI/credentials.py
+++ b/src/PermutiveAPI/credentials.py
@@ -1,0 +1,106 @@
+"""Credential providers for local and plugin-driven SDK use."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Optional, Protocol, Sequence
+
+from dotenv import dotenv_values
+
+
+class CredentialsError(RuntimeError):
+    """Raised when credentials cannot be resolved safely."""
+
+
+@dataclass(frozen=True)
+class Credentials:
+    """Resolved Permutive credentials.
+
+    Parameters
+    ----------
+    api_key
+        Permutive API key.
+    source
+        Human-readable source identifier that never contains the secret.
+    """
+
+    api_key: str
+    source: str
+
+    def __repr__(self) -> str:
+        """Return a representation that never exposes the API key."""
+        return f"Credentials(api_key='[REDACTED]', source={self.source!r})"
+
+
+class CredentialsProvider(Protocol):
+    """Contract implemented by credential provider plugins."""
+
+    def load(self) -> Credentials:
+        """Resolve credentials or raise ``CredentialsError``."""
+        ...
+
+
+class LocalCredentialsProvider:
+    """Resolve credentials from explicit input, environment, or local files.
+
+    Resolution order is deterministic:
+
+    1. explicit ``api_key``
+    2. process environment
+    3. configured dotenv files, in order
+
+    The provider never mutates ``os.environ`` and never returns a blank key.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        *,
+        env_var: str = "PERMUTIVE_API_KEY",
+        dotenv_paths: Optional[Sequence[Path | str]] = None,
+        environ: Optional[Mapping[str, str]] = None,
+    ) -> None:
+        self._api_key = api_key
+        self._env_var = env_var
+        self._dotenv_paths = tuple(
+            Path(path).expanduser()
+            for path in (
+                dotenv_paths
+                if dotenv_paths is not None
+                else (Path.cwd() / ".env", Path.home() / ".config/permutive/.env")
+            )
+        )
+        self._environ = environ if environ is not None else os.environ
+
+    def load(self) -> Credentials:
+        """Resolve the first valid local credential."""
+        explicit = self._normalize(self._api_key)
+        if explicit is not None:
+            return Credentials(explicit, "explicit")
+
+        environment = self._normalize(self._environ.get(self._env_var))
+        if environment is not None:
+            return Credentials(environment, f"environment:{self._env_var}")
+
+        for path in self._dotenv_paths:
+            if not path.is_file():
+                continue
+            value = self._normalize(dotenv_values(path).get(self._env_var))
+            if value is not None:
+                return Credentials(value, f"dotenv:{path}")
+
+        searched = ", ".join(str(path) for path in self._dotenv_paths)
+        raise CredentialsError(
+            f"No Permutive API key found in explicit input, {self._env_var}, "
+            f"or dotenv files: {searched}"
+        )
+
+    @staticmethod
+    def _normalize(value: object) -> Optional[str]:
+        """Return a stripped non-empty string value."""
+        if not isinstance(value, str):
+            return None
+        normalized = value.strip()
+        return normalized or None

--- a/src/PermutiveAPI/credentials.py
+++ b/src/PermutiveAPI/credentials.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Mapping, Optional, Protocol, Sequence
+from typing import Mapping, Optional, Protocol, Sequence, Union
 
 from dotenv import dotenv_values
 
@@ -45,13 +45,8 @@ class CredentialsProvider(Protocol):
 class LocalCredentialsProvider:
     """Resolve credentials from explicit input, environment, or local files.
 
-    Resolution order is deterministic:
-
-    1. explicit ``api_key``
-    2. process environment
-    3. configured dotenv files, in order
-
-    The provider never mutates ``os.environ`` and never returns a blank key.
+    Resolution order is deterministic: explicit input, process environment,
+    then configured dotenv files. The provider never mutates ``os.environ``.
     """
 
     def __init__(
@@ -59,7 +54,7 @@ class LocalCredentialsProvider:
         api_key: Optional[str] = None,
         *,
         env_var: str = "PERMUTIVE_API_KEY",
-        dotenv_paths: Optional[Sequence[Path | str]] = None,
+        dotenv_paths: Optional[Sequence[Union[Path, str]]] = None,
         environ: Optional[Mapping[str, str]] = None,
     ) -> None:
         self._api_key = api_key

--- a/src/PermutiveAPI/plugins/__init__.py
+++ b/src/PermutiveAPI/plugins/__init__.py
@@ -1,0 +1,13 @@
+"""Public plugin API."""
+
+from .base import PLUGIN_ENTRY_POINT_GROUP, Plugin, PluginMetadata, discover_plugins
+from .codex import CodexPlugin, create_client
+
+__all__ = [
+    "PLUGIN_ENTRY_POINT_GROUP",
+    "CodexPlugin",
+    "Plugin",
+    "PluginMetadata",
+    "create_client",
+    "discover_plugins",
+]

--- a/src/PermutiveAPI/plugins/base.py
+++ b/src/PermutiveAPI/plugins/base.py
@@ -1,0 +1,52 @@
+"""Stable plugin surface for PermutiveAPI integrations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib.metadata import entry_points
+from typing import Dict, Iterable, Protocol
+
+from ..client import PermutiveClient
+from ..credentials import CredentialsProvider
+
+PLUGIN_ENTRY_POINT_GROUP = "permutiveapi.plugins"
+
+
+@dataclass(frozen=True)
+class PluginMetadata:
+    """Stable metadata exposed by a PermutiveAPI plugin."""
+
+    name: str
+    version: str
+    description: str
+    capabilities: tuple[str, ...]
+
+
+class Plugin(Protocol):
+    """Contract for first-class PermutiveAPI plugins."""
+
+    @property
+    def metadata(self) -> PluginMetadata:
+        """Return immutable plugin metadata."""
+        ...
+
+    def create_client(self, credentials: CredentialsProvider) -> PermutiveClient:
+        """Create an authenticated Permutive client."""
+        ...
+
+
+def discover_plugins() -> Dict[str, Plugin]:
+    """Discover installed plugins through Python package entry points."""
+    discovered: Dict[str, Plugin] = {}
+    selected = entry_points()
+    candidates: Iterable[object]
+    if hasattr(selected, "select"):
+        candidates = selected.select(group=PLUGIN_ENTRY_POINT_GROUP)
+    else:  # pragma: no cover - Python 3.9 compatibility path
+        candidates = selected.get(PLUGIN_ENTRY_POINT_GROUP, ())
+
+    for candidate in candidates:
+        plugin_type = candidate.load()
+        plugin = plugin_type()
+        discovered[plugin.metadata.name] = plugin
+    return discovered

--- a/src/PermutiveAPI/plugins/codex.py
+++ b/src/PermutiveAPI/plugins/codex.py
@@ -1,0 +1,38 @@
+"""First-class Codex integration for PermutiveAPI."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from ..client import PermutiveClient
+from ..credentials import CredentialsProvider, LocalCredentialsProvider
+from .base import PluginMetadata
+
+
+class CodexPlugin:
+    """Codex-facing plugin with secure local credential resolution."""
+
+    @property
+    def metadata(self) -> PluginMetadata:
+        """Return the Codex plugin contract."""
+        return PluginMetadata(
+            name="codex",
+            version="1",
+            description="Authenticated PermutiveAPI surface for Codex agents.",
+            capabilities=("client", "local-credentials", "resource-api"),
+        )
+
+    def create_client(
+        self, credentials: Optional[CredentialsProvider] = None
+    ) -> PermutiveClient:
+        """Create a client using the supplied or default local provider."""
+        provider = credentials or LocalCredentialsProvider()
+        resolved = provider.load()
+        return PermutiveClient(resolved.api_key)
+
+
+def create_client(
+    credentials: Optional[CredentialsProvider] = None,
+) -> PermutiveClient:
+    """Create a Codex-ready client with one import and sensible defaults."""
+    return CodexPlugin().create_client(credentials)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,66 @@
+"""Tests for plugin and local credential surfaces."""
+
+from pathlib import Path
+
+import pytest
+
+from PermutiveAPI.credentials import (
+    Credentials,
+    CredentialsError,
+    LocalCredentialsProvider,
+)
+from PermutiveAPI.plugins.codex import CodexPlugin
+
+
+def test_local_credentials_precedence(tmp_path: Path) -> None:
+    """Explicit credentials take precedence over environment and dotenv."""
+    dotenv_path = tmp_path / ".env"
+    dotenv_path.write_text("PERMUTIVE_API_KEY=file-key\n", encoding="utf-8")
+    provider = LocalCredentialsProvider(
+        " explicit-key ",
+        environ={"PERMUTIVE_API_KEY": "environment-key"},
+        dotenv_paths=[dotenv_path],
+    )
+
+    assert provider.load() == Credentials("explicit-key", "explicit")
+
+
+def test_local_credentials_load_dotenv_without_mutating_environment(
+    tmp_path: Path,
+) -> None:
+    """Dotenv credentials are read directly and their source is retained."""
+    dotenv_path = tmp_path / ".env"
+    dotenv_path.write_text("PERMUTIVE_API_KEY=file-key\n", encoding="utf-8")
+    environment = {}
+
+    credentials = LocalCredentialsProvider(
+        environ=environment, dotenv_paths=[dotenv_path]
+    ).load()
+
+    assert credentials.api_key == "file-key"
+    assert credentials.source == f"dotenv:{dotenv_path}"
+    assert environment == {}
+    assert "file-key" not in repr(credentials)
+
+
+def test_local_credentials_raise_when_missing(tmp_path: Path) -> None:
+    """Missing credentials fail with an actionable error."""
+    with pytest.raises(CredentialsError, match="PERMUTIVE_API_KEY"):
+        LocalCredentialsProvider(
+            environ={}, dotenv_paths=[tmp_path / "missing.env"]
+        ).load()
+
+
+def test_codex_plugin_creates_authenticated_client() -> None:
+    """The Codex plugin accepts any credentials provider contract."""
+
+    class Provider:
+        def load(self) -> Credentials:
+            return Credentials("test-key", "test")
+
+    plugin = CodexPlugin()
+    client = plugin.create_client(Provider())
+
+    assert plugin.metadata.name == "codex"
+    assert "local-credentials" in plugin.metadata.capabilities
+    assert client._api_key == "test-key"


### PR DESCRIPTION
## Summary
- add a stable `permutiveapi.plugins` entry-point surface
- ship a built-in `codex` plugin with a one-call client factory
- add a first-class local credentials provider with deterministic precedence
- redact credentials from representations and avoid mutating `os.environ`
- add Python 3.9-compatible typing and focused tests

## Credential precedence
1. explicit API key
2. `PERMUTIVE_API_KEY` environment variable
3. project `.env`
4. `~/.config/permutive/.env`

## Validation
Tests were added for precedence, dotenv loading, missing credentials, redaction, and Codex client creation. The connected environment could not execute the test suite because the repository could not be cloned through the local network sandbox.