### PR TITLE
Add first-class agent and plugin tooling

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,57 @@
+# Agent and Plugin Integration
+
+PermutiveAPI uses one framework-neutral tool layer for agents, plugins, and custom runtimes.
+
+## Architecture
+
+- `PermutiveAPI.tools` defines stable tool metadata, discovery, invocation, and exports.
+- `PermutiveAPI.agent` combines local SDK tools with the official hosted Permutive MCP connection.
+- `PermutiveAPI.mcp` configures the hosted MCP server without duplicating its tools.
+- `PermutiveAPI.plugins` remains the extension mechanism for runtime-specific adapters.
+
+The REST SDK remains the deterministic application interface. Agent tools are thin, explicit adapters over SDK operations. Hosted MCP tools remain owned and versioned by Permutive.
+
+## Define a tool
+
+```python
+from PermutiveAPI.tools import ToolRegistry, tool
+
+
+@tool(
+    description="Return one cohort by identifier.",
+    input_schema={
+        "type": "object",
+        "properties": {"cohort_id": {"type": "string"}},
+        "required": ["cohort_id"],
+        "additionalProperties": False,
+    },
+    tags=("cohorts", "read"),
+)
+def get_cohort(cohort_id: str) -> dict[str, object]:
+    return {"id": cohort_id}
+
+
+registry = ToolRegistry([get_cohort])
+```
+
+## Use with an agent runtime
+
+```python
+from PermutiveAPI.agent import PermutiveAgentKit
+from PermutiveAPI.mcp import PermutiveMCPConfig
+
+kit = PermutiveAgentKit(
+    registry,
+    mcp=PermutiveMCPConfig.from_env(),
+)
+
+function_tools = kit.openai_tools()
+hosted_mcp = kit.mcp_config()
+result = kit.invoke("get_cohort", {"cohort_id": "cohort-123"})
+```
+
+## Contract
+
+Tool names are stable public API. Inputs use strict JSON Schema. Tool handlers validate argument names through their Python signatures. Read and write capabilities are explicitly labelled so agents and approval layers can distinguish safe discovery from mutations.
+
+Framework-specific integrations should adapt `ToolRegistry`; they should not introduce a second tool definition format.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PermutiveAPI"
-version = "6.2.0"
+version = "6.3.0"
 description = "A typed Python SDK for the Permutive API."
 readme = "README.md"
 authors = [{ name = "FaTmamBo33", email = "fatmambo33@gmail.com" }]
@@ -75,6 +75,7 @@ line-length = 88
 [tool.pyright]
 include = [
     "src/PermutiveAPI/__init__.py",
+    "src/PermutiveAPI/agent.py",
     "src/PermutiveAPI/client.py",
     "src/PermutiveAPI/credentials.py",
     "src/PermutiveAPI/mcp.py",
@@ -82,6 +83,7 @@ include = [
     "src/PermutiveAPI/plugins",
     "src/PermutiveAPI/resources.py",
     "src/PermutiveAPI/sdk.py",
+    "src/PermutiveAPI/tools.py",
 ]
 extraPaths = ["src"]
 typeCheckingMode = "strict"

--- a/src/PermutiveAPI/__init__.py
+++ b/src/PermutiveAPI/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
+from .agent import PermutiveAgentKit
 from .client import PermutiveClient
 from .mcp import (
     PERMUTIVE_MCP_DOCUMENTATION_URL,
@@ -41,6 +42,7 @@ from .sdk import (
     ValidationError,
     execute_batch,
 )
+from .tools import JSONSchema, ToolDefinition, ToolHandler, ToolRegistry, tool
 from .utils.http import (
     PermutiveAPIError,
     PermutiveAuthenticationError,
@@ -108,6 +110,7 @@ __all__ = [
     "ImportList",
     "JSONObject",
     "JSONScalar",
+    "JSONSchema",
     "JSONValue",
     "NotFoundError",
     "PERMUTIVE_MCP_DOCUMENTATION_URL",
@@ -116,6 +119,7 @@ __all__ = [
     "PERMUTIVE_MCP_URL_ENV",
     "Page",
     "PermutiveAPIError",
+    "PermutiveAgentKit",
     "PermutiveAuthenticationError",
     "PermutiveBadRequestError",
     "PermutiveClient",
@@ -133,9 +137,13 @@ __all__ = [
     "Segmentation",
     "ServerError",
     "Source",
+    "ToolDefinition",
+    "ToolHandler",
+    "ToolRegistry",
     "TransportError",
     "ValidationError",
     "Workspace",
     "WorkspaceList",
     "execute_batch",
+    "tool",
 ]

--- a/src/PermutiveAPI/agent.py
+++ b/src/PermutiveAPI/agent.py
@@ -1,0 +1,54 @@
+"""Agent-facing integration helpers built on the neutral tool registry."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .mcp import PermutiveMCPConfig
+from .tools import ToolRegistry
+
+
+class PermutiveAgentKit:
+    """Bundle SDK tools and hosted MCP configuration for agent runtimes.
+
+    Parameters
+    ----------
+    tools
+        Framework-neutral tool registry.
+    mcp
+        Optional connection to Permutive's official hosted MCP server.
+    """
+
+    def __init__(
+        self,
+        tools: ToolRegistry | None = None,
+        *,
+        mcp: PermutiveMCPConfig | None = None,
+    ) -> None:
+        self.tools = tools or ToolRegistry()
+        self.mcp = mcp
+
+    def capabilities(self) -> dict[str, Any]:
+        """Return machine-readable capabilities for adaptive agents."""
+        capabilities = self.tools.capabilities()
+        capabilities["official_mcp"] = self.mcp is not None
+        return capabilities
+
+    def openai_tools(self) -> list[dict[str, Any]]:
+        """Export local tools in OpenAI-compatible function format."""
+        return self.tools.as_openai_tools()
+
+    def mcp_config(self) -> dict[str, object] | None:
+        """Return the hosted MCP client fragment when configured."""
+        return None if self.mcp is None else self.mcp.to_client_config()
+
+    def invoke(
+        self,
+        name: str,
+        arguments: Mapping[str, Any] | None = None,
+    ) -> Any:
+        """Execute a local tool call returned by an agent runtime."""
+        return self.tools.invoke(name, arguments)
+
+
+__all__ = ["PermutiveAgentKit"]

--- a/src/PermutiveAPI/tools.py
+++ b/src/PermutiveAPI/tools.py
@@ -1,0 +1,132 @@
+"""Framework-neutral tools for agent and plugin integrations."""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Sequence, get_type_hints
+
+JSONSchema = dict[str, Any]
+ToolHandler = Callable[..., Any]
+
+
+@dataclass(frozen=True, slots=True)
+class ToolDefinition:
+    """Describe one callable exposed to agents.
+
+    Parameters
+    ----------
+    name
+        Stable machine-readable tool name.
+    description
+        Human-readable instructions for model tool selection.
+    input_schema
+        JSON Schema describing accepted arguments.
+    handler
+        Python callable implementing the operation.
+    tags
+        Optional capability labels used for discovery and filtering.
+    read_only
+        Whether calling the tool can mutate Permutive state.
+    """
+
+    name: str
+    description: str
+    input_schema: JSONSchema
+    handler: ToolHandler
+    tags: tuple[str, ...] = ()
+    read_only: bool = True
+
+    def invoke(self, arguments: Mapping[str, Any] | None = None) -> Any:
+        """Invoke the tool with validated argument names."""
+        values = dict(arguments or {})
+        signature = inspect.signature(self.handler)
+        signature.bind(**values)
+        return self.handler(**values)
+
+    def as_openai_tool(self) -> dict[str, Any]:
+        """Return the OpenAI-compatible function-tool representation."""
+        return {
+            "type": "function",
+            "name": self.name,
+            "description": self.description,
+            "parameters": self.input_schema,
+            "strict": True,
+        }
+
+
+class ToolRegistry:
+    """Register, discover, export, and invoke framework-neutral tools."""
+
+    def __init__(self, tools: Sequence[ToolDefinition] = ()) -> None:
+        self._tools: dict[str, ToolDefinition] = {}
+        for tool in tools:
+            self.register(tool)
+
+    def register(self, tool: ToolDefinition, *, replace: bool = False) -> None:
+        """Register a tool while protecting stable names from collisions."""
+        if not tool.name or not tool.name.replace("_", "").isalnum():
+            raise ValueError("Tool names must contain only letters, digits, and underscores.")
+        if tool.name in self._tools and not replace:
+            raise ValueError(f"Tool already registered: {tool.name}")
+        self._tools[tool.name] = tool
+
+    def get(self, name: str) -> ToolDefinition:
+        """Return a registered tool by name."""
+        try:
+            return self._tools[name]
+        except KeyError as exc:
+            raise KeyError(f"Unknown tool: {name}") from exc
+
+    def list(self, *, tag: str | None = None) -> tuple[ToolDefinition, ...]:
+        """List tools deterministically, optionally filtered by tag."""
+        tools = self._tools.values()
+        if tag is not None:
+            tools = (tool for tool in tools if tag in tool.tags)
+        return tuple(sorted(tools, key=lambda tool: tool.name))
+
+    def invoke(self, name: str, arguments: Mapping[str, Any] | None = None) -> Any:
+        """Invoke a registered tool."""
+        return self.get(name).invoke(arguments)
+
+    def capabilities(self) -> dict[str, Any]:
+        """Return a machine-readable capability summary."""
+        tools = self.list()
+        return {
+            "agent_tools": bool(tools),
+            "tool_count": len(tools),
+            "read_only_tools": sum(tool.read_only for tool in tools),
+            "write_tools": sum(not tool.read_only for tool in tools),
+            "tags": sorted({tag for tool in tools for tag in tool.tags}),
+        }
+
+    def as_openai_tools(self) -> list[dict[str, Any]]:
+        """Export all tools for OpenAI-compatible agents."""
+        return [tool.as_openai_tool() for tool in self.list()]
+
+
+def tool(
+    *,
+    name: str | None = None,
+    description: str,
+    input_schema: JSONSchema,
+    tags: Sequence[str] = (),
+    read_only: bool = True,
+) -> Callable[[ToolHandler], ToolDefinition]:
+    """Decorate a callable as a framework-neutral agent tool."""
+
+    def decorate(handler: ToolHandler) -> ToolDefinition:
+        get_type_hints(handler)
+        return ToolDefinition(
+            name=name or handler.__name__,
+            description=description.strip(),
+            input_schema=dict(input_schema),
+            handler=handler,
+            tags=tuple(tags),
+            read_only=read_only,
+        )
+
+    return decorate
+
+
+__all__ = ["JSONSchema", "ToolDefinition", "ToolHandler", "ToolRegistry", "tool"]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,84 @@
+"""Tests for framework-neutral agent tooling."""
+
+from __future__ import annotations
+
+import pytest
+
+from PermutiveAPI.agent import PermutiveAgentKit
+from PermutiveAPI.mcp import PermutiveMCPConfig
+from PermutiveAPI.tools import ToolDefinition, ToolRegistry, tool
+
+
+SCHEMA = {
+    "type": "object",
+    "properties": {"value": {"type": "integer"}},
+    "required": ["value"],
+    "additionalProperties": False,
+}
+
+
+def increment(value: int) -> int:
+    """Increment a value."""
+    return value + 1
+
+
+def test_registry_registers_exports_and_invokes_tools() -> None:
+    definition = ToolDefinition(
+        name="increment",
+        description="Increment an integer.",
+        input_schema=SCHEMA,
+        handler=increment,
+        tags=("test",),
+    )
+    registry = ToolRegistry([definition])
+
+    assert registry.invoke("increment", {"value": 2}) == 3
+    assert registry.list(tag="test") == (definition,)
+    assert registry.as_openai_tools() == [
+        {
+            "type": "function",
+            "name": "increment",
+            "description": "Increment an integer.",
+            "parameters": SCHEMA,
+            "strict": True,
+        }
+    ]
+
+
+def test_registry_rejects_duplicates_and_unknown_tools() -> None:
+    definition = ToolDefinition("increment", "Increment.", SCHEMA, increment)
+    registry = ToolRegistry([definition])
+
+    with pytest.raises(ValueError, match="already registered"):
+        registry.register(definition)
+    with pytest.raises(KeyError, match="Unknown tool"):
+        registry.invoke("missing")
+
+
+def test_tool_decorator_creates_definition() -> None:
+    @tool(description="Increment.", input_schema=SCHEMA, tags=("math",))
+    def decorated(value: int) -> int:
+        return value + 1
+
+    assert decorated.name == "decorated"
+    assert decorated.tags == ("math",)
+    assert decorated.invoke({"value": 4}) == 5
+
+
+def test_agent_kit_reports_local_and_mcp_capabilities() -> None:
+    registry = ToolRegistry(
+        [ToolDefinition("increment", "Increment.", SCHEMA, increment)]
+    )
+    mcp = PermutiveMCPConfig(url="https://example.com/mcp")
+    kit = PermutiveAgentKit(registry, mcp=mcp)
+
+    assert kit.capabilities() == {
+        "agent_tools": True,
+        "tool_count": 1,
+        "read_only_tools": 1,
+        "write_tools": 0,
+        "tags": [],
+        "official_mcp": True,
+    }
+    assert kit.invoke("increment", {"value": 8}) == 9
+    assert kit.mcp_config() == mcp.to_client_config()


### PR DESCRIPTION
## What changed

- adds a framework-neutral `ToolDefinition` and `ToolRegistry`
- exports strict OpenAI-compatible function tool schemas
- adds `PermutiveAgentKit` to combine local SDK tools with the official hosted MCP configuration
- exposes machine-readable capability discovery and controlled tool invocation
- documents the stable architecture and plugin boundary
- adds contract tests for registration, discovery, export, invocation, MCP composition, and failure cases
- includes the new modules in strict Pyright coverage
- prepares the backward-compatible 6.3.0 minor release

## Why

PermutiveAPI needs one canonical tool definition layer that can serve agents, plugins, MCP-aware clients, and future framework adapters without duplicating business logic or coupling the core SDK to a specific AI framework.

## Validation

The repository CI is expected to run pytest, coverage, style, and strict typing checks. The design preserves the dependency-free core agent surface and keeps Permutive's hosted MCP server separately owned and versioned.