### PR TITLE
Verify the SDK public API contract

### DIFF
--- a/API_COVERAGE.md
+++ b/API_COVERAGE.md
@@ -1,6 +1,6 @@
 # API Coverage
 
-This matrix defines the Permutive API surface supported by the canonical SDK.
+This matrix defines the Permutive API and integration surfaces supported by the canonical SDK.
 
 | Domain | Canonical entry point | Operations | Status |
 |---|---|---|---|
@@ -9,17 +9,22 @@ This matrix defines the Permutive API surface supported by the canonical SDK.
 | Segments | `client.segments` | get, list, iterate, create, update, delete | Supported |
 | Sources | `client.sources` | get, list, iterate, create, update, delete | Supported |
 | Workspaces | `client.workspaces` | get, list, iterate, create, update, delete | Supported |
+| Agent capabilities | `PermutiveAgentKit` | discover and expose SDK capabilities | Supported |
+| Tool integration | `ToolRegistry` / `tool` | register, describe, and invoke typed tools | Supported |
+| MCP composition | `PermutiveMCPConfig` | compose hosted MCP server configuration | Supported |
+| Codex plugin | `permutiveapi.plugins` entry point | load `CodexPlugin` | Supported |
 | Identity | legacy `Identity` / `Alias` | identify and batch identify | Compatibility |
 | User segmentation | legacy `Segmentation` / `Event` | segment and batch segment | Compatibility |
 | Context segmentation | legacy `ContextSegment` | segment page context | Compatibility |
 
 ## Coverage rules
 
-- A supported operation must have a documented SDK entry point, typed signature, deterministic contract test, and structured errors.
+- A supported operation must have a documented SDK entry point, typed signature, deterministic contract test, and structured errors where transport is involved.
+- Supported integration surfaces must have stable package-root imports and package metadata where discovery is required.
 - Compatibility operations remain supported but may delegate to canonical transport code while their final resource shape is designed.
-- An endpoint not listed here is intentionally unsupported until it receives an implementation, tests, and documentation.
+- An endpoint or integration not listed here is intentionally unsupported until it receives an implementation, tests, and documentation.
 - API-specific behavior belongs in resource or action adapters, not in generic transport code.
 
 ## Adding coverage
 
-Every new endpoint change must update this matrix and include request, response, error, and pagination tests where applicable.
+Every new endpoint change must update this matrix and include request, response, error, and pagination tests where applicable. Every new integration surface must update `PUBLIC_API.md`, package metadata, and import-level regression tests.

--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -5,7 +5,7 @@ This document is the source of truth for public support, deprecation, and remova
 
 ## Canonical surface
 
-New code should use these exports from `PermutiveAPI`:
+New code should use these exports from `PermutiveAPI`.
 
 ### Client and resources
 
@@ -30,6 +30,23 @@ New code should use these exports from `PermutiveAPI`:
 - `BatchItem`
 - `BatchResult`
 - `execute_batch`
+
+### Agent and tool integration
+
+- `PermutiveAgentKit`
+- `JSONSchema`
+- `ToolDefinition`
+- `ToolHandler`
+- `ToolRegistry`
+- `tool`
+
+### MCP integration
+
+- `PermutiveMCPConfig`
+- `PERMUTIVE_MCP_DOCUMENTATION_URL`
+- `PERMUTIVE_MCP_SERVER_NAME`
+- `PERMUTIVE_MCP_TOKEN_ENV`
+- `PERMUTIVE_MCP_URL_ENV`
 
 ### Canonical errors
 
@@ -93,7 +110,9 @@ Users must not rely on imports from private modules or names prefixed with `_`.
 
 ## Decision rules
 
-- Prefer `PermutiveClient` and `Resource` for all new work.
+- Prefer `PermutiveClient` and `Resource` for all new API work.
+- Prefer `PermutiveAgentKit` and `ToolRegistry` for agent integrations.
+- Use `PermutiveMCPConfig` for MCP server composition rather than duplicating environment handling.
 - Do not add a second way to perform the same operation without a documented product reason.
 - Public methods require stable names, typed signatures, documented errors, tests, and examples.
 - Compatibility code delegates to canonical code rather than duplicating request logic.
@@ -101,4 +120,4 @@ Users must not rely on imports from private modules or names prefixed with `_`.
 
 ## Migration direction
 
-Core CRUD resources are available through the canonical client. Identity, user segmentation, and context segmentation remain compatibility actions while their endpoint contracts stabilize. `API_COVERAGE.md` records the exact support status and `MIGRATION.md` provides the supported transition path.
+Core CRUD resources are available through the canonical client. Identity, user segmentation, and context segmentation remain compatibility actions while their endpoint contracts stabilize. Agent, tool, and MCP integrations are canonical extension surfaces. `API_COVERAGE.md` records the exact support status and `MIGRATION.md` provides the supported transition path.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ codex = "PermutiveAPI.plugins.codex:CodexPlugin"
 [project.optional-dependencies]
 dataframe = ["pandas>=2"]
 dev = [
-    "black==26.3.1",
+    "black==25.11.0",
     "build>=1",
     "pandas>=2",
     "pydocstyle>=6",

--- a/tests/test_distribution_contract.py
+++ b/tests/test_distribution_contract.py
@@ -1,0 +1,57 @@
+"""Tests for the built wheel distribution contract."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from zipfile import ZipFile
+
+
+def test_wheel_contains_typed_package_and_plugin_metadata(tmp_path: Path) -> None:
+    """Ensure the wheel ships the supported package and discovery metadata."""
+    project_root = Path(__file__).resolve().parents[1]
+    output_dir = tmp_path / "dist"
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "build",
+            "--wheel",
+            "--no-isolation",
+            "--outdir",
+            str(output_dir),
+        ],
+        cwd=project_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    wheels = list(output_dir.glob("*.whl"))
+    assert len(wheels) == 1
+
+    with ZipFile(wheels[0]) as wheel:
+        names = set(wheel.namelist())
+        entry_points_name = next(
+            name for name in names if name.endswith(".dist-info/entry_points.txt")
+        )
+        entry_points = wheel.read(entry_points_name).decode("utf-8")
+
+    required_package_files = {
+        "PermutiveAPI/__init__.py",
+        "PermutiveAPI/agent.py",
+        "PermutiveAPI/client.py",
+        "PermutiveAPI/mcp.py",
+        "PermutiveAPI/py.typed",
+        "PermutiveAPI/resources.py",
+        "PermutiveAPI/sdk.py",
+        "PermutiveAPI/tools.py",
+        "PermutiveAPI/plugins/__init__.py",
+        "PermutiveAPI/plugins/codex.py",
+    }
+    assert required_package_files <= names
+    assert not any(name.startswith("tests/") for name in names)
+    assert not any(name.startswith("docs/") for name in names)
+    assert "[permutiveapi.plugins]" in entry_points
+    assert "codex = PermutiveAPI.plugins.codex:CodexPlugin" in entry_points

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from importlib import import_module
+
 import PermutiveAPI
 
 EXPECTED_PUBLIC_API = {
@@ -25,13 +27,20 @@ EXPECTED_PUBLIC_API = {
     "ImportList",
     "JSONObject",
     "JSONScalar",
+    "JSONSchema",
     "JSONValue",
     "NotFoundError",
+    "PERMUTIVE_MCP_DOCUMENTATION_URL",
+    "PERMUTIVE_MCP_SERVER_NAME",
+    "PERMUTIVE_MCP_TOKEN_ENV",
+    "PERMUTIVE_MCP_URL_ENV",
     "Page",
     "PermutiveAPIError",
+    "PermutiveAgentKit",
     "PermutiveAuthenticationError",
     "PermutiveBadRequestError",
     "PermutiveClient",
+    "PermutiveMCPConfig",
     "PermutiveRateLimitError",
     "PermutiveResourceNotFoundError",
     "PermutiveServerError",
@@ -45,11 +54,15 @@ EXPECTED_PUBLIC_API = {
     "SegmentationPayload",
     "ServerError",
     "Source",
+    "ToolDefinition",
+    "ToolHandler",
+    "ToolRegistry",
     "TransportError",
     "ValidationError",
     "Workspace",
     "WorkspaceList",
     "execute_batch",
+    "tool",
 }
 
 
@@ -59,6 +72,16 @@ def test_public_api_is_explicit_and_complete() -> None:
 
     for public_name in PermutiveAPI.__all__:
         assert hasattr(PermutiveAPI, public_name), public_name
+
+
+def test_public_api_supports_explicit_package_root_imports() -> None:
+    """Ensure every documented symbol supports a direct root import."""
+    package = import_module("PermutiveAPI")
+
+    for public_name in EXPECTED_PUBLIC_API:
+        namespace: dict[str, object] = {}
+        exec(f"from PermutiveAPI import {public_name}", namespace)
+        assert namespace[public_name] is getattr(package, public_name)
 
 
 def test_public_api_does_not_contain_duplicates() -> None:


### PR DESCRIPTION
Closes #125.

## Summary
- align `PUBLIC_API.md` with the 6.3.0 agent, tool, MCP, and plugin surface
- update `API_COVERAGE.md` for supported integration entry points
- expand package-root import regression coverage to every exported symbol
- build and inspect the wheel to verify typed package files and plugin metadata

## Validation
- GitHub Actions must pass formatting, strict typing, tests, coverage, and package validation before merge