### PR TITLE
Define the 6.4 architecture and compatibility contract

### DIFF
--- a/docs/adr/0001-6.4-architecture-and-compatibility.md
+++ b/docs/adr/0001-6.4-architecture-and-compatibility.md
@@ -1,0 +1,68 @@
+# ADR 0001: PermutiveAPI 6.4 architecture and compatibility
+
+## Status
+
+Accepted for the 6.4 roadmap.
+
+## Context
+
+PermutiveAPI already exposes a canonical synchronous client, typed resource primitives, compatibility exports, agent tooling, plugin entry points, and MCP configuration. Version 6.4 adds asynchronous access and further production capabilities. Those additions must not fragment the SDK or create parallel business logic.
+
+## Decision
+
+### Canonical layers
+
+1. **Models and contracts** contain typed request, response, pagination, batch, query, error, and configuration types.
+2. **Transport** owns authentication, URL construction, timeouts, retries, decoding, redaction, and request diagnostics.
+3. **Clients** expose synchronous and asynchronous lifecycle and resource namespaces.
+4. **Resources** implement endpoint behavior once against a minimal transport protocol.
+5. **Integrations** such as CLI, MCP, plugins, notebooks, telemetry, and DataFrames remain thin adapters over canonical clients and contracts.
+
+### Sync and async parity
+
+- `PermutiveClient` remains the canonical synchronous entry point.
+- `AsyncPermutiveClient` is the canonical asynchronous entry point.
+- Both clients use the same models, resource semantics, error hierarchy, configuration rules, retry classification, redaction, pagination guards, and batch outcome contracts.
+- Async implementations must not call synchronous network code or duplicate endpoint-specific business logic.
+
+### Compatibility
+
+- Version 6.4 is backward compatible with the documented 6.3 public surface.
+- Additive public APIs may ship in 6.4.
+- Existing package-root exports and supported signatures may not be removed or incompatibly changed.
+- Compatibility exports delegate to canonical implementations and must not own independent transport logic.
+- A removal requires prior deprecation, migration guidance, a documented removal version, and a major release.
+
+### Optional dependencies
+
+Core installation remains sufficient for the synchronous SDK. Async transport, CLI, OpenTelemetry, pandas, Polars, MCP, and other integrations must be isolated behind optional extras or dependency-free adapters. Importing `PermutiveAPI` must not import optional packages.
+
+### Extension boundaries
+
+- `ToolRegistry` and `PermutiveAgentKit` remain the canonical agent/tool layer.
+- `PermutiveMCPConfig` remains the canonical MCP composition layer.
+- Plugin and CLI code call public SDK APIs only.
+- No integration may duplicate credential resolution, HTTP behavior, serialization, retries, or error mapping.
+
+## Non-goals
+
+- Replacing the synchronous client.
+- Introducing a second resource hierarchy.
+- Rewriting compatibility models solely for stylistic consistency.
+- Making optional integrations mandatory.
+- Adding implicit retries for unsafe writes.
+
+## Enforceable rules
+
+The 6.4 implementation and CI must verify:
+
+- package-root export and signature compatibility;
+- core-wheel imports without optional dependencies;
+- sync and async contract parity for supported operations;
+- one shared error and redaction contract;
+- compatibility adapters contain no direct network calls;
+- new public exports are documented in `PUBLIC_API.md` and covered by contract tests.
+
+## Consequences
+
+New features must fit the existing client/resource architecture. Some work may require shared protocols or extracted endpoint functions, but those abstractions must reduce duplication and remain small. Integrations can evolve independently while the core SDK stays predictable and lightweight.


### PR DESCRIPTION
## Summary
- add ADR 0001 for the PermutiveAPI 6.4 architecture
- define canonical layers, sync/async parity, compatibility rules, optional dependency boundaries, and extension contracts
- make the roadmap constraints explicit and testable

## Impact
This establishes the implementation boundary for the remaining 6.4 roadmap and prevents duplicate clients, resources, transport behavior, and integration logic.

Closes #130