### PR TITLE
Add public API and behavior regression matrix

### DIFF
--- a/COMPATIBILITY_MATRIX.md
+++ b/COMPATIBILITY_MATRIX.md
@@ -1,0 +1,47 @@
+# Compatibility Matrix
+
+This document defines the public compatibility contract for PermutiveAPI 6.4.
+
+## Supported runtimes
+
+| Area | Contract |
+|---|---|
+| Python | 3.9 through 3.13 |
+| Core install | Imports without optional integrations |
+| Public API | Symbols listed in `PermutiveAPI.__all__` |
+| Canonical client | `PermutiveClient` |
+| Canonical resources | `Resource[T]` namespaces |
+| Compatibility exports | Supported until a documented deprecation cycle completes |
+
+## Stable behavior
+
+The following behavior is protected by regression tests:
+
+- package-root exports remain explicit and importable;
+- canonical resource methods remain `get`, `list`, `list_page`, `iter_all`, `create`, `update`, and `delete`;
+- `PermutiveClient` continues to expose `cohorts`, `imports`, `segments`, `sources`, and `workspaces` resource namespaces;
+- compatibility exports delegate to the canonical implementation rather than defining a second transport contract;
+- the core package imports without pandas, Polars, OpenTelemetry, CLI, async, MCP, or plugin extras;
+- backward-compatible additions may ship in minor releases;
+- removals require a documented deprecation period and a major release.
+
+## Change policy
+
+| Change | Allowed release |
+|---|---|
+| Add optional public symbol | Minor |
+| Add optional method parameter | Minor |
+| Add response field support | Patch or minor |
+| Change public signature incompatibly | Major |
+| Remove compatibility export | Major, after deprecation |
+| Require a new optional dependency in core | Not allowed |
+
+## Validation
+
+CI must fail when:
+
+- a package-root export is added or removed without updating the public contract;
+- a canonical resource method disappears or changes its required parameter shape;
+- a supported resource namespace disappears;
+- an optional integration becomes required for a core import;
+- a compatibility export is removed without migration and deprecation records.

--- a/tests/test_compatibility_contract.py
+++ b/tests/test_compatibility_contract.py
@@ -1,0 +1,44 @@
+"""Regression tests for the supported SDK behavior contract."""
+
+from __future__ import annotations
+
+from inspect import signature
+
+from PermutiveAPI import PermutiveClient, Resource
+
+
+def test_client_keeps_supported_resource_namespaces() -> None:
+    """Protect the canonical resource-oriented client surface."""
+    expected = {"cohorts", "imports", "segments", "sources", "workspaces"}
+    assert expected <= set(vars(PermutiveClient))
+
+
+def test_resource_keeps_canonical_operations() -> None:
+    """Protect the common CRUD, pagination, and iteration vocabulary."""
+    expected = {
+        "get",
+        "list",
+        "list_page",
+        "iter_all",
+        "create",
+        "update",
+        "delete",
+    }
+    assert expected <= set(vars(Resource))
+
+
+def test_resource_required_parameter_shapes_are_stable() -> None:
+    """Catch incompatible changes to required public parameters."""
+    assert tuple(signature(Resource.get).parameters) == ("self", "resource_id")
+    assert tuple(signature(Resource.create).parameters) == ("self", "payload")
+    assert tuple(signature(Resource.update).parameters) == (
+        "self",
+        "resource_id",
+        "payload",
+    )
+    assert tuple(signature(Resource.delete).parameters) == ("self", "resource_id")
+
+
+def test_list_alias_matches_canonical_list_signature() -> None:
+    """Keep the compatibility alias behaviorally aligned with list."""
+    assert signature(Resource.list_page) == signature(Resource.list)


### PR DESCRIPTION
## Summary
- document the supported Python, public API, optional dependency, and release compatibility matrix
- protect canonical client resource namespaces
- protect resource operation names and required parameter shapes
- keep `list_page` aligned with `list`

## Validation
The added tests are deterministic and require no network or credentials.

Closes #141