### PR TITLE
Release PermutiveAPI 6.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to PermutiveAPI are documented here. The project follows Semantic Versioning.
 
+## 6.4.0 - 2026-08-05
+
+### Added
+- Strictly typed `AsyncPermutiveClient` with optional HTTPX transport and async context management.
+- Typed async resource CRUD, pagination, lazy iteration, ordered bounded batches, partial-failure outcomes, and cancellation-safe cleanup.
+- Immutable typed query composition helpers with deterministic JSON serialization.
+- Shared typed configuration and redacted secret contracts with HTTPS-by-default endpoint validation.
+- Public API, architecture, deprecation, packaging, and Python 3.9–3.13 compatibility contracts.
+
+### Changed
+- Preserved the synchronous API and legacy package-root exports while extending the canonical SDK surface.
+- Kept async support optional through `PermutiveAPI[async]`.
+- Strengthened strict typing, deterministic tests, wheel-content checks, clean-install validation, and release documentation.
+
+### Scope
+- The release intentionally ships the coherent async, query, configuration, and security foundation.
+- CLI, telemetry, caching, webhooks, bulk workflows, additional dataframe integrations, mock-server tooling, schema monitoring, and advanced resilience features are deferred to later releases rather than expanding the 6.4 minor release indefinitely.
+
 ## 6.1.0 - 2026-08-04
 
 ### Added

--- a/docs/releases/6.4.0.md
+++ b/docs/releases/6.4.0.md
@@ -1,0 +1,49 @@
+# PermutiveAPI 6.4.0
+
+PermutiveAPI 6.4.0 is a backward-compatible minor release focused on a small, coherent production SDK surface.
+
+## Install
+
+```bash
+pip install PermutiveAPI==6.4.0
+```
+
+For asynchronous HTTP support:
+
+```bash
+pip install "PermutiveAPI[async]==6.4.0"
+```
+
+## Async client
+
+```python
+from PermutiveAPI import AsyncPermutiveClient
+
+async with AsyncPermutiveClient("api-key") as client:
+    payload = await client.request("GET", "cohorts/example")
+```
+
+Mutating requests are not retried implicitly. Pass `idempotent=True` only when the caller can guarantee safe replay semantics.
+
+## Async resources and batches
+
+`AsyncResource` provides typed CRUD and pagination over the canonical client. `execute_async_batch` preserves input order, bounds concurrency, captures partial failures, and cancels child tasks safely when the parent is cancelled.
+
+## Query composition
+
+Use `event`, `property_condition`, `in_segment`, `all_of`, and `any_of` to build immutable, deterministic query payloads. Existing raw payload APIs remain supported.
+
+## Configuration and security
+
+`PermutiveConfig` centralizes validated settings. `Secret` redacts credentials from string and representation output. Remote endpoints require HTTPS by default; local development HTTP requires an explicit opt-in.
+
+## Compatibility
+
+- Python 3.9 through 3.13.
+- Existing synchronous constructors and legacy exports remain available.
+- HTTPX is not imported by the core synchronous installation.
+- Wheels and source distributions are validated through clean installation checks.
+
+## Deferred scope
+
+The roadmap originally mixed the core release with CLI, telemetry, caching, webhooks, bulk workflows, mock servers, schema monitoring, and advanced resilience. Those features are intentionally deferred so 6.4.0 remains lean, reviewable, and backward compatible.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PermutiveAPI"
-version = "6.3.0"
+version = "6.4.0"
 description = "A typed Python SDK for the Permutive API."
 readme = "README.md"
 authors = [{ name = "FaTmamBo33", email = "fatmambo33@gmail.com" }]


### PR DESCRIPTION
Closes #143.
Closes #144.
Closes #129.

## Release scope
- version the package as 6.4.0
- document the async client, async resources and batches, query composition, configuration, and security contracts
- preserve synchronous and legacy compatibility
- record the intentionally deferred follow-on roadmap scope

## Merge gate
Formatting, NumPy docstrings, strict Pyright, deterministic tests with coverage, Python 3.9–3.13, package build, Twine validation, and clean wheel installation must all pass before merge.