### PR TITLE
Add framework-neutral structured request diagnostics

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,0 +1,19 @@
+# Structured diagnostics
+
+PermutiveAPI exposes framework-neutral transport wrappers for safe request diagnostics. The wrappers are optional and add no cost unless explicitly installed around a transport.
+
+```python
+import logging
+import requests
+
+from PermutiveAPI import PermutiveClient
+from PermutiveAPI.diagnostics import DiagnosticTransport
+
+logger = logging.getLogger("permutive")
+transport = DiagnosticTransport(requests.Session(), lambda event: logger.info("permutive_request", extra={"permutive": event}))
+client = PermutiveClient("api-key", transport=transport)
+```
+
+Use `AsyncDiagnosticTransport` around an async transport for the same event contract.
+
+Events contain only the request phase, HTTP method, endpoint without query parameters, attempt number, duration, status, request ID, and exception type. Request payloads, query parameters, credentials, and exception messages are never emitted.

--- a/src/PermutiveAPI/diagnostics.py
+++ b/src/PermutiveAPI/diagnostics.py
@@ -1,0 +1,187 @@
+"""Framework-neutral request diagnostics for sync and async transports."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Dict, Mapping, Optional, Protocol, Tuple
+from urllib.parse import urlsplit, urlunsplit
+
+
+@dataclass(frozen=True)
+class RequestDiagnostic:
+    """Safe structured metadata for one transport attempt."""
+
+    phase: str
+    method: str
+    endpoint: str
+    attempt: int
+    duration: float
+    status_code: Optional[int] = None
+    request_id: Optional[str] = None
+    error_type: Optional[str] = None
+
+
+DiagnosticHook = Callable[[RequestDiagnostic], None]
+
+
+class SyncResponse(Protocol):
+    """Response fields required by the diagnostic wrapper."""
+
+    status_code: int
+    headers: Mapping[str, str]
+
+
+class SyncTransport(Protocol):
+    """Synchronous transport accepted by :class:`DiagnosticTransport`."""
+
+    def request(self, method: str, url: str, **kwargs: Any) -> SyncResponse:
+        """Send one request."""
+        ...
+
+
+class AsyncResponse(Protocol):
+    """Asynchronous response fields required by the diagnostic wrapper."""
+
+    status_code: int
+    headers: Mapping[str, str]
+
+
+class AsyncTransport(Protocol):
+    """Asynchronous transport accepted by :class:`AsyncDiagnosticTransport`."""
+
+    async def request(self, method: str, url: str, **kwargs: Any) -> AsyncResponse:
+        """Send one asynchronous request."""
+        ...
+
+    async def aclose(self) -> None:
+        """Close transport resources."""
+        ...
+
+
+def _safe_endpoint(url: str) -> str:
+    """Remove query parameters and fragments from a diagnostic endpoint."""
+    parts = urlsplit(url)
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+
+
+def _request_id(headers: Mapping[str, str]) -> Optional[str]:
+    """Extract a common request identifier header."""
+    return headers.get("X-Request-ID") or headers.get("Request-ID")
+
+
+def _is_retryable(status_code: int) -> bool:
+    """Return whether a response commonly participates in SDK retries."""
+    return status_code == 429 or status_code >= 500
+
+
+class DiagnosticTransport:
+    """Wrap a synchronous transport and emit safe request metadata."""
+
+    def __init__(self, transport: SyncTransport, hook: DiagnosticHook) -> None:
+        self._transport = transport
+        self._hook = hook
+        self._attempts: Dict[Tuple[str, str], int] = {}
+
+    def request(self, method: str, url: str, **kwargs: Any) -> SyncResponse:
+        """Delegate one request while emitting start and completion events."""
+        verb = method.upper()
+        endpoint = _safe_endpoint(url)
+        key = (verb, endpoint)
+        attempt = self._attempts.get(key, 0) + 1
+        self._attempts[key] = attempt
+        started = time.monotonic()
+        self._hook(RequestDiagnostic("start", verb, endpoint, attempt, 0.0))
+        try:
+            response = self._transport.request(method, url, **kwargs)
+        except Exception as exc:
+            self._hook(
+                RequestDiagnostic(
+                    "error",
+                    verb,
+                    endpoint,
+                    attempt,
+                    time.monotonic() - started,
+                    error_type=type(exc).__name__,
+                )
+            )
+            raise
+        self._hook(
+            RequestDiagnostic(
+                "end",
+                verb,
+                endpoint,
+                attempt,
+                time.monotonic() - started,
+                status_code=response.status_code,
+                request_id=_request_id(response.headers),
+            )
+        )
+        if not _is_retryable(response.status_code):
+            self._attempts.pop(key, None)
+        return response
+
+    def close(self) -> None:
+        """Close the wrapped transport when supported."""
+        close = getattr(self._transport, "close", None)
+        if callable(close):
+            close()
+
+
+class AsyncDiagnosticTransport:
+    """Wrap an asynchronous transport and emit safe request metadata."""
+
+    def __init__(self, transport: AsyncTransport, hook: DiagnosticHook) -> None:
+        self._transport = transport
+        self._hook = hook
+        self._attempts: Dict[Tuple[str, str], int] = {}
+
+    async def request(self, method: str, url: str, **kwargs: Any) -> AsyncResponse:
+        """Delegate one request while emitting start and completion events."""
+        verb = method.upper()
+        endpoint = _safe_endpoint(url)
+        key = (verb, endpoint)
+        attempt = self._attempts.get(key, 0) + 1
+        self._attempts[key] = attempt
+        started = time.monotonic()
+        self._hook(RequestDiagnostic("start", verb, endpoint, attempt, 0.0))
+        try:
+            response = await self._transport.request(method, url, **kwargs)
+        except Exception as exc:
+            self._hook(
+                RequestDiagnostic(
+                    "error",
+                    verb,
+                    endpoint,
+                    attempt,
+                    time.monotonic() - started,
+                    error_type=type(exc).__name__,
+                )
+            )
+            raise
+        self._hook(
+            RequestDiagnostic(
+                "end",
+                verb,
+                endpoint,
+                attempt,
+                time.monotonic() - started,
+                status_code=response.status_code,
+                request_id=_request_id(response.headers),
+            )
+        )
+        if not _is_retryable(response.status_code):
+            self._attempts.pop(key, None)
+        return response
+
+    async def aclose(self) -> None:
+        """Close the wrapped asynchronous transport."""
+        await self._transport.aclose()
+
+
+__all__ = [
+    "AsyncDiagnosticTransport",
+    "DiagnosticHook",
+    "DiagnosticTransport",
+    "RequestDiagnostic",
+]

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,110 @@
+"""Tests for framework-neutral request diagnostics."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping
+
+import pytest
+
+from PermutiveAPI.diagnostics import (
+    AsyncDiagnosticTransport,
+    DiagnosticTransport,
+    RequestDiagnostic,
+)
+
+
+class Response:
+    """Small response double."""
+
+    def __init__(
+        self, status_code: int, headers: Mapping[str, str] | None = None
+    ) -> None:
+        self.status_code = status_code
+        self.headers = dict(headers or {})
+
+
+class SyncTransport:
+    """Ordered synchronous transport double."""
+
+    def __init__(self, *responses: Response) -> None:
+        self.responses = list(responses)
+        self.closed = False
+
+    def request(self, method: str, url: str, **kwargs: Any) -> Response:
+        """Return the next response."""
+        return self.responses.pop(0)
+
+    def close(self) -> None:
+        """Record closure."""
+        self.closed = True
+
+
+class AsyncTransport:
+    """Ordered asynchronous transport double."""
+
+    def __init__(self, *responses: Response) -> None:
+        self.responses = list(responses)
+        self.closed = False
+
+    async def request(self, method: str, url: str, **kwargs: Any) -> Response:
+        """Return the next response."""
+        return self.responses.pop(0)
+
+    async def aclose(self) -> None:
+        """Record closure."""
+        self.closed = True
+
+
+def test_sync_diagnostics_are_safe_and_track_retries() -> None:
+    """Emit safe metadata with retry attempts and request identifiers."""
+    events: List[RequestDiagnostic] = []
+    wrapped = DiagnosticTransport(
+        SyncTransport(
+            Response(429),
+            Response(200, {"X-Request-ID": "request-2"}),
+        ),
+        events.append,
+    )
+
+    wrapped.request("get", "https://api.example.test/items?k=secret", json={"token": "x"})
+    wrapped.request("get", "https://api.example.test/items?k=secret", json={"token": "x"})
+
+    completed = [event for event in events if event.phase == "end"]
+    assert [event.attempt for event in completed] == [1, 2]
+    assert completed[-1].request_id == "request-2"
+    assert all("secret" not in event.endpoint for event in events)
+    assert all("token" not in repr(event) for event in events)
+
+
+def test_sync_diagnostics_emit_error_type_without_message() -> None:
+    """Avoid leaking exception messages into diagnostic metadata."""
+    events: List[RequestDiagnostic] = []
+
+    class FailingTransport:
+        def request(self, method: str, url: str, **kwargs: Any) -> Response:
+            raise RuntimeError("credential-secret")
+
+    wrapped = DiagnosticTransport(FailingTransport(), events.append)
+    with pytest.raises(RuntimeError, match="credential-secret"):
+        wrapped.request("GET", "https://api.example.test/items")
+
+    error = events[-1]
+    assert error.phase == "error"
+    assert error.error_type == "RuntimeError"
+    assert "credential-secret" not in repr(error)
+
+
+@pytest.mark.asyncio
+async def test_async_diagnostics_match_sync_contract() -> None:
+    """Emit equivalent metadata for asynchronous transports."""
+    events: List[RequestDiagnostic] = []
+    transport = AsyncTransport(Response(204, {"Request-ID": "async-1"}))
+    wrapped = AsyncDiagnosticTransport(transport, events.append)
+
+    response = await wrapped.request("delete", "https://api.example.test/items/1?k=x")
+    await wrapped.aclose()
+
+    assert response.status_code == 204
+    assert events[-1].method == "DELETE"
+    assert events[-1].request_id == "async-1"
+    assert transport.closed

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -66,8 +66,12 @@ def test_sync_diagnostics_are_safe_and_track_retries() -> None:
         events.append,
     )
 
-    wrapped.request("get", "https://api.example.test/items?k=secret", json={"token": "x"})
-    wrapped.request("get", "https://api.example.test/items?k=secret", json={"token": "x"})
+    wrapped.request(
+        "get", "https://api.example.test/items?k=secret", json={"token": "x"}
+    )
+    wrapped.request(
+        "get", "https://api.example.test/items?k=secret", json={"token": "x"}
+    )
 
     completed = [event for event in events if event.phase == "end"]
     assert [event.attempt for event in completed] == [1, 2]

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Mapping
+from typing import Any, List, Mapping, Optional
 
 import pytest
 
@@ -17,7 +17,7 @@ class Response:
     """Small response double."""
 
     def __init__(
-        self, status_code: int, headers: Mapping[str, str] | None = None
+        self, status_code: int, headers: Optional[Mapping[str, str]] = None
     ) -> None:
         self.status_code = status_code
         self.headers = dict(headers or {})


### PR DESCRIPTION
Closes #136.

## Summary
- add opt-in synchronous and asynchronous diagnostic transport wrappers
- emit safe structured lifecycle metadata without logging dependencies
- expose method, endpoint, duration, status, request ID, exception type, and retry-attempt information
- omit query parameters, payloads, credentials, and exception messages
- add deterministic sync and async contract tests and a logging adapter example

## Validation
Merge after formatting, NumPy docstrings, strict typing, package checks, coverage, and Python 3.9–3.13 tests pass.