### PR TITLE
Build a first-class Codex plugin surface

### DIFF
--- a/src/PermutiveAPI/plugins/__init__.py
+++ b/src/PermutiveAPI/plugins/__init__.py
@@ -1,13 +1,24 @@
 """Public plugin API."""
 
-from .base import PLUGIN_ENTRY_POINT_GROUP, Plugin, PluginMetadata, discover_plugins
+from .base import (
+    PLUGIN_API_VERSION,
+    PLUGIN_ENTRY_POINT_GROUP,
+    Plugin,
+    PluginMetadata,
+    discover_plugins,
+)
 from .codex import CodexPlugin, create_client
+from .runtime import PluginMode, PluginPolicy, ValidationReport
 
 __all__ = [
+    "PLUGIN_API_VERSION",
     "PLUGIN_ENTRY_POINT_GROUP",
     "CodexPlugin",
     "Plugin",
     "PluginMetadata",
+    "PluginMode",
+    "PluginPolicy",
+    "ValidationReport",
     "create_client",
     "discover_plugins",
 ]

--- a/src/PermutiveAPI/plugins/base.py
+++ b/src/PermutiveAPI/plugins/base.py
@@ -6,10 +6,14 @@ from dataclasses import dataclass
 from importlib.metadata import entry_points
 from typing import Dict, Iterable, Protocol
 
+from ..agent import PermutiveAgentKit
 from ..client import PermutiveClient
 from ..credentials import CredentialsProvider
+from ..tools import ToolRegistry
+from .runtime import ValidationReport
 
 PLUGIN_ENTRY_POINT_GROUP = "permutiveapi.plugins"
+PLUGIN_API_VERSION = "1"
 
 
 @dataclass(frozen=True)
@@ -17,7 +21,9 @@ class PluginMetadata:
     """Stable metadata exposed by a PermutiveAPI plugin."""
 
     name: str
-    version: str
+    plugin_version: str
+    sdk_version: str
+    api_version: str
     description: str
     capabilities: tuple[str, ...]
 
@@ -30,13 +36,31 @@ class Plugin(Protocol):
         """Return immutable plugin metadata."""
         ...
 
-    def create_client(self, credentials: CredentialsProvider) -> PermutiveClient:
+    def create_client(
+        self, credentials: CredentialsProvider | None = None
+    ) -> PermutiveClient:
         """Create an authenticated Permutive client."""
+        ...
+
+    def tools(self) -> ToolRegistry:
+        """Return tools allowed by the active plugin policy."""
+        ...
+
+    def agent_kit(self) -> PermutiveAgentKit:
+        """Return a complete agent integration bundle."""
+        ...
+
+    def validate(self) -> ValidationReport:
+        """Validate plugin configuration without exposing secrets."""
+        ...
+
+    def close(self) -> None:
+        """Release resources owned by the plugin."""
         ...
 
 
 def discover_plugins() -> Dict[str, Plugin]:
-    """Discover installed plugins through Python package entry points."""
+    """Discover and validate installed plugins through package entry points."""
     discovered: Dict[str, Plugin] = {}
     selected = entry_points()
     candidates: Iterable[object]
@@ -48,5 +72,22 @@ def discover_plugins() -> Dict[str, Plugin]:
     for candidate in candidates:
         plugin_type = candidate.load()
         plugin = plugin_type()
-        discovered[plugin.metadata.name] = plugin
+        metadata = plugin.metadata
+        if metadata.api_version != PLUGIN_API_VERSION:
+            raise RuntimeError(
+                f"Unsupported plugin API version for {metadata.name}: "
+                f"{metadata.api_version}"
+            )
+        if metadata.name in discovered:
+            raise RuntimeError(f"Duplicate plugin name: {metadata.name}")
+        discovered[metadata.name] = plugin
     return discovered
+
+
+__all__ = [
+    "PLUGIN_API_VERSION",
+    "PLUGIN_ENTRY_POINT_GROUP",
+    "Plugin",
+    "PluginMetadata",
+    "discover_plugins",
+]

--- a/src/PermutiveAPI/plugins/codex.py
+++ b/src/PermutiveAPI/plugins/codex.py
@@ -2,37 +2,254 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any, Mapping
 
+from ..agent import PermutiveAgentKit
 from ..client import PermutiveClient
-from ..credentials import CredentialsProvider, LocalCredentialsProvider
-from .base import PluginMetadata
+from ..credentials import CredentialsError, CredentialsProvider, LocalCredentialsProvider
+from ..mcp import PermutiveMCPConfig
+from ..tools import ToolDefinition, ToolRegistry
+from .base import PLUGIN_API_VERSION, PluginMetadata
+from .runtime import PluginPolicy, ValidationReport
+
+
+def _sdk_version() -> str:
+    try:
+        return version("PermutiveAPI")
+    except PackageNotFoundError:  # pragma: no cover - editable source tree
+        return "0+unknown"
 
 
 class CodexPlugin:
-    """Codex-facing plugin with secure local credential resolution."""
+    """Cohesive, safe Codex-facing PermutiveAPI integration."""
+
+    def __init__(
+        self,
+        credentials: CredentialsProvider | None = None,
+        *,
+        policy: PluginPolicy | None = None,
+        mcp: PermutiveMCPConfig | None = None,
+    ) -> None:
+        self._credentials = credentials or LocalCredentialsProvider()
+        self._policy = policy or PluginPolicy()
+        self._mcp = mcp
+        self._client: PermutiveClient | None = None
+        self._tools: ToolRegistry | None = None
+
+    @classmethod
+    def from_env(
+        cls,
+        *,
+        mode: str = "read_only",
+        allowed_tools: set[str] | None = None,
+        require_confirmation_for_writes: bool = True,
+        mcp: PermutiveMCPConfig | None = None,
+    ) -> "CodexPlugin":
+        """Create a plugin using secure local credential resolution."""
+        if mode not in {"read_only", "read_write"}:
+            raise ValueError("mode must be 'read_only' or 'read_write'")
+        policy = PluginPolicy(
+            mode=mode,  # type: ignore[arg-type]
+            allowed_tools=None if allowed_tools is None else frozenset(allowed_tools),
+            require_confirmation_for_writes=require_confirmation_for_writes,
+        )
+        return cls(policy=policy, mcp=mcp)
 
     @property
     def metadata(self) -> PluginMetadata:
-        """Return the Codex plugin contract."""
+        """Return the stable Codex plugin contract."""
         return PluginMetadata(
             name="codex",
-            version="1",
-            description="Authenticated PermutiveAPI surface for Codex agents.",
-            capabilities=("client", "local-credentials", "resource-api"),
+            plugin_version="1.0",
+            sdk_version=_sdk_version(),
+            api_version=PLUGIN_API_VERSION,
+            description="Safe PermutiveAPI tools and MCP configuration for agents.",
+            capabilities=(
+                "client",
+                "agent-tools",
+                "local-credentials",
+                "official-mcp",
+                "read-write-policy",
+            ),
         )
 
     def create_client(
-        self, credentials: Optional[CredentialsProvider] = None
+        self, credentials: CredentialsProvider | None = None
     ) -> PermutiveClient:
-        """Create a client using the supplied or default local provider."""
-        provider = credentials or LocalCredentialsProvider()
-        resolved = provider.load()
-        return PermutiveClient(resolved.api_key)
+        """Create or return an authenticated Permutive client."""
+        if credentials is not None:
+            resolved = credentials.load()
+            return PermutiveClient(resolved.api_key)
+        if self._client is None:
+            resolved = self._credentials.load()
+            self._client = PermutiveClient(resolved.api_key)
+        return self._client
+
+    def tools(self) -> ToolRegistry:
+        """Return the curated tools allowed by the active policy."""
+        if self._tools is None:
+            client = self.create_client()
+            definitions = (
+                ToolDefinition(
+                    name="permutive_list_cohorts",
+                    description="List Permutive cohorts with bounded pagination.",
+                    input_schema={
+                        "type": "object",
+                        "properties": {
+                            "page_size": {"type": "integer", "minimum": 1, "maximum": 100}
+                        },
+                        "additionalProperties": False,
+                    },
+                    handler=lambda page_size=100: client.list_page(
+                        "cohorts", page_size=page_size
+                    ).items,
+                    tags=("cohorts", "read"),
+                ),
+                ToolDefinition(
+                    name="permutive_get_cohort",
+                    description="Get one Permutive cohort by identifier.",
+                    input_schema={
+                        "type": "object",
+                        "properties": {"cohort_id": {"type": "string", "minLength": 1}},
+                        "required": ["cohort_id"],
+                        "additionalProperties": False,
+                    },
+                    handler=lambda cohort_id: client.request("GET", f"cohorts/{cohort_id}"),
+                    tags=("cohorts", "read"),
+                ),
+                ToolDefinition(
+                    name="permutive_list_segments",
+                    description="List Permutive audience segments with bounded pagination.",
+                    input_schema={
+                        "type": "object",
+                        "properties": {
+                            "page_size": {"type": "integer", "minimum": 1, "maximum": 100}
+                        },
+                        "additionalProperties": False,
+                    },
+                    handler=lambda page_size=100: client.list_page(
+                        "segments", page_size=page_size
+                    ).items,
+                    tags=("segments", "read"),
+                ),
+                ToolDefinition(
+                    name="permutive_get_workspace",
+                    description="Get one Permutive workspace by identifier.",
+                    input_schema={
+                        "type": "object",
+                        "properties": {"workspace_id": {"type": "string", "minLength": 1}},
+                        "required": ["workspace_id"],
+                        "additionalProperties": False,
+                    },
+                    handler=lambda workspace_id: client.request(
+                        "GET", f"workspaces/{workspace_id}"
+                    ),
+                    tags=("workspaces", "read"),
+                ),
+                ToolDefinition(
+                    name="permutive_create_cohort",
+                    description="Create a Permutive cohort from a validated JSON payload.",
+                    input_schema={
+                        "type": "object",
+                        "properties": {"payload": {"type": "object"}},
+                        "required": ["payload"],
+                        "additionalProperties": False,
+                    },
+                    handler=lambda payload: client.request("POST", "cohorts", json=payload),
+                    tags=("cohorts", "write"),
+                    read_only=False,
+                ),
+                ToolDefinition(
+                    name="permutive_update_cohort",
+                    description="Update a Permutive cohort from a validated JSON payload.",
+                    input_schema={
+                        "type": "object",
+                        "properties": {
+                            "cohort_id": {"type": "string", "minLength": 1},
+                            "payload": {"type": "object"},
+                        },
+                        "required": ["cohort_id", "payload"],
+                        "additionalProperties": False,
+                    },
+                    handler=lambda cohort_id, payload: client.request(
+                        "PATCH", f"cohorts/{cohort_id}", json=payload
+                    ),
+                    tags=("cohorts", "write"),
+                    read_only=False,
+                ),
+            )
+            self._tools = ToolRegistry(
+                tuple(
+                    definition
+                    for definition in definitions
+                    if self._policy.allows(
+                        definition.name, read_only=definition.read_only
+                    )
+                )
+            )
+        return self._tools
+
+    def agent_kit(self) -> PermutiveAgentKit:
+        """Return one complete agent integration bundle."""
+        return PermutiveAgentKit(self.tools(), mcp=self._mcp)
+
+    def invoke(
+        self,
+        name: str,
+        arguments: Mapping[str, Any] | None = None,
+        *,
+        confirmed: bool = False,
+    ) -> Any:
+        """Invoke a tool while enforcing write confirmation policy."""
+        definition = self.tools().get(name)
+        if (
+            not definition.read_only
+            and self._policy.require_confirmation_for_writes
+            and not confirmed
+        ):
+            raise PermissionError(f"Write tool requires explicit confirmation: {name}")
+        return definition.invoke(arguments)
+
+    def validate(self) -> ValidationReport:
+        """Validate credentials and policy without making an API request."""
+        checks = ["plugin-api", "policy"]
+        errors: list[str] = []
+        try:
+            self._credentials.load()
+            checks.append("credentials")
+        except CredentialsError as exc:
+            errors.append(str(exc))
+        if self._mcp is not None:
+            checks.append("official-mcp")
+        return ValidationReport(not errors, tuple(checks), tuple(errors))
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Return a secret-safe runtime summary."""
+        report = self.validate()
+        return {
+            "metadata": self.metadata,
+            "policy": {
+                "mode": self._policy.mode,
+                "write_confirmation": self._policy.require_confirmation_for_writes,
+            },
+            "tools": self.tools().capabilities() if report.valid else None,
+            "validation": report,
+        }
+
+    def close(self) -> None:
+        """Close the owned client and clear cached runtime state."""
+        if self._client is not None:
+            self._client.close()
+        self._client = None
+        self._tools = None
 
 
 def create_client(
-    credentials: Optional[CredentialsProvider] = None,
+    credentials: CredentialsProvider | None = None,
 ) -> PermutiveClient:
     """Create a Codex-ready client with one import and sensible defaults."""
-    return CodexPlugin().create_client(credentials)
+    return CodexPlugin(credentials).create_client()
+
+
+__all__ = ["CodexPlugin", "create_client"]

--- a/src/PermutiveAPI/plugins/codex.py
+++ b/src/PermutiveAPI/plugins/codex.py
@@ -3,21 +3,22 @@
 from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
-from typing import Any, Mapping
+from typing import Any, Mapping, cast
 
 from ..agent import PermutiveAgentKit
 from ..client import PermutiveClient
 from ..credentials import CredentialsError, CredentialsProvider, LocalCredentialsProvider
 from ..mcp import PermutiveMCPConfig
+from ..sdk import JSONObject
 from ..tools import ToolDefinition, ToolRegistry
 from .base import PLUGIN_API_VERSION, PluginMetadata
-from .runtime import PluginPolicy, ValidationReport
+from .runtime import PluginMode, PluginPolicy, ValidationReport
 
 
 def _sdk_version() -> str:
     try:
         return version("PermutiveAPI")
-    except PackageNotFoundError:  # pragma: no cover - editable source tree
+    except PackageNotFoundError:  # pragma: no cover
         return "0+unknown"
 
 
@@ -49,12 +50,16 @@ class CodexPlugin:
         """Create a plugin using secure local credential resolution."""
         if mode not in {"read_only", "read_write"}:
             raise ValueError("mode must be 'read_only' or 'read_write'")
-        policy = PluginPolicy(
-            mode=mode,  # type: ignore[arg-type]
-            allowed_tools=None if allowed_tools is None else frozenset(allowed_tools),
-            require_confirmation_for_writes=require_confirmation_for_writes,
+        return cls(
+            policy=PluginPolicy(
+                mode=cast(PluginMode, mode),
+                allowed_tools=(
+                    None if allowed_tools is None else frozenset(allowed_tools)
+                ),
+                require_confirmation_for_writes=require_confirmation_for_writes,
+            ),
+            mcp=mcp,
         )
-        return cls(policy=policy, mcp=mcp)
 
     @property
     def metadata(self) -> PluginMetadata:
@@ -79,113 +84,86 @@ class CodexPlugin:
     ) -> PermutiveClient:
         """Create or return an authenticated Permutive client."""
         if credentials is not None:
-            resolved = credentials.load()
-            return PermutiveClient(resolved.api_key)
+            return PermutiveClient(credentials.load().api_key)
         if self._client is None:
-            resolved = self._credentials.load()
-            self._client = PermutiveClient(resolved.api_key)
+            self._client = PermutiveClient(self._credentials.load().api_key)
         return self._client
+
+    @staticmethod
+    def _object_schema(*, required: tuple[str, ...] = ()) -> dict[str, Any]:
+        properties: dict[str, Any] = {
+            "resource_id": {"type": "string", "minLength": 1},
+            "payload": {"type": "object"},
+            "page_size": {"type": "integer", "minimum": 1, "maximum": 100},
+        }
+        schema: dict[str, Any] = {
+            "type": "object",
+            "properties": properties,
+            "additionalProperties": False,
+        }
+        if required:
+            schema["required"] = list(required)
+        return schema
+
+    def _definitions(self, client: PermutiveClient) -> tuple[ToolDefinition, ...]:
+        return (
+            ToolDefinition(
+                "permutive_list_cohorts",
+                "List Permutive cohorts with bounded pagination.",
+                self._object_schema(),
+                lambda page_size=100: client.cohorts.list(page_size=page_size).items,
+                ("cohorts", "read"),
+            ),
+            ToolDefinition(
+                "permutive_get_cohort",
+                "Get one Permutive cohort by identifier.",
+                self._object_schema(required=("resource_id",)),
+                lambda resource_id: client.cohorts.get(resource_id),
+                ("cohorts", "read"),
+            ),
+            ToolDefinition(
+                "permutive_list_segments",
+                "List Permutive audience segments with bounded pagination.",
+                self._object_schema(),
+                lambda page_size=100: client.segments.list(page_size=page_size).items,
+                ("segments", "read"),
+            ),
+            ToolDefinition(
+                "permutive_get_workspace",
+                "Get one Permutive workspace by identifier.",
+                self._object_schema(required=("resource_id",)),
+                lambda resource_id: client.workspaces.get(resource_id),
+                ("workspaces", "read"),
+            ),
+            ToolDefinition(
+                "permutive_create_cohort",
+                "Create a Permutive cohort from a JSON payload.",
+                self._object_schema(required=("payload",)),
+                lambda payload: client.cohorts.create(cast(JSONObject, payload)),
+                ("cohorts", "write"),
+                False,
+            ),
+            ToolDefinition(
+                "permutive_update_cohort",
+                "Update a Permutive cohort from a JSON payload.",
+                self._object_schema(required=("resource_id", "payload")),
+                lambda resource_id, payload: client.cohorts.update(
+                    resource_id, cast(JSONObject, payload)
+                ),
+                ("cohorts", "write"),
+                False,
+            ),
+        )
 
     def tools(self) -> ToolRegistry:
         """Return the curated tools allowed by the active policy."""
         if self._tools is None:
-            client = self.create_client()
-            definitions = (
-                ToolDefinition(
-                    name="permutive_list_cohorts",
-                    description="List Permutive cohorts with bounded pagination.",
-                    input_schema={
-                        "type": "object",
-                        "properties": {
-                            "page_size": {"type": "integer", "minimum": 1, "maximum": 100}
-                        },
-                        "additionalProperties": False,
-                    },
-                    handler=lambda page_size=100: client.list_page(
-                        "cohorts", page_size=page_size
-                    ).items,
-                    tags=("cohorts", "read"),
-                ),
-                ToolDefinition(
-                    name="permutive_get_cohort",
-                    description="Get one Permutive cohort by identifier.",
-                    input_schema={
-                        "type": "object",
-                        "properties": {"cohort_id": {"type": "string", "minLength": 1}},
-                        "required": ["cohort_id"],
-                        "additionalProperties": False,
-                    },
-                    handler=lambda cohort_id: client.request("GET", f"cohorts/{cohort_id}"),
-                    tags=("cohorts", "read"),
-                ),
-                ToolDefinition(
-                    name="permutive_list_segments",
-                    description="List Permutive audience segments with bounded pagination.",
-                    input_schema={
-                        "type": "object",
-                        "properties": {
-                            "page_size": {"type": "integer", "minimum": 1, "maximum": 100}
-                        },
-                        "additionalProperties": False,
-                    },
-                    handler=lambda page_size=100: client.list_page(
-                        "segments", page_size=page_size
-                    ).items,
-                    tags=("segments", "read"),
-                ),
-                ToolDefinition(
-                    name="permutive_get_workspace",
-                    description="Get one Permutive workspace by identifier.",
-                    input_schema={
-                        "type": "object",
-                        "properties": {"workspace_id": {"type": "string", "minLength": 1}},
-                        "required": ["workspace_id"],
-                        "additionalProperties": False,
-                    },
-                    handler=lambda workspace_id: client.request(
-                        "GET", f"workspaces/{workspace_id}"
-                    ),
-                    tags=("workspaces", "read"),
-                ),
-                ToolDefinition(
-                    name="permutive_create_cohort",
-                    description="Create a Permutive cohort from a validated JSON payload.",
-                    input_schema={
-                        "type": "object",
-                        "properties": {"payload": {"type": "object"}},
-                        "required": ["payload"],
-                        "additionalProperties": False,
-                    },
-                    handler=lambda payload: client.request("POST", "cohorts", json=payload),
-                    tags=("cohorts", "write"),
-                    read_only=False,
-                ),
-                ToolDefinition(
-                    name="permutive_update_cohort",
-                    description="Update a Permutive cohort from a validated JSON payload.",
-                    input_schema={
-                        "type": "object",
-                        "properties": {
-                            "cohort_id": {"type": "string", "minLength": 1},
-                            "payload": {"type": "object"},
-                        },
-                        "required": ["cohort_id", "payload"],
-                        "additionalProperties": False,
-                    },
-                    handler=lambda cohort_id, payload: client.request(
-                        "PATCH", f"cohorts/{cohort_id}", json=payload
-                    ),
-                    tags=("cohorts", "write"),
-                    read_only=False,
-                ),
-            )
+            definitions = self._definitions(self.create_client())
             self._tools = ToolRegistry(
                 tuple(
-                    definition
-                    for definition in definitions
-                    if self._policy.allows(
-                        definition.name, read_only=definition.read_only
-                    )
+                    item
+                    for item in definitions
+                    if self._policy.allows(item.name, read_only=item.read_only)
                 )
             )
         return self._tools

--- a/src/PermutiveAPI/plugins/runtime.py
+++ b/src/PermutiveAPI/plugins/runtime.py
@@ -1,0 +1,35 @@
+"""Safe runtime policy and validation primitives for PermutiveAPI plugins."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+PluginMode = Literal["read_only", "read_write"]
+
+
+@dataclass(frozen=True)
+class PluginPolicy:
+    """Control which plugin operations may be exposed to an agent."""
+
+    mode: PluginMode = "read_only"
+    allowed_tools: frozenset[str] | None = None
+    require_confirmation_for_writes: bool = True
+
+    def allows(self, name: str, *, read_only: bool) -> bool:
+        """Return whether a tool is allowed by this policy."""
+        if self.allowed_tools is not None and name not in self.allowed_tools:
+            return False
+        return read_only or self.mode == "read_write"
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    """Describe whether a plugin is ready for use."""
+
+    valid: bool
+    checks: tuple[str, ...]
+    errors: tuple[str, ...] = ()
+
+
+__all__ = ["PluginMode", "PluginPolicy", "ValidationReport"]

--- a/tests/test_codex_plugin_surface.py
+++ b/tests/test_codex_plugin_surface.py
@@ -1,0 +1,80 @@
+"""Contract tests for the first-class Codex plugin surface."""
+
+from __future__ import annotations
+
+from PermutiveAPI.credentials import Credentials
+from PermutiveAPI.plugins import CodexPlugin, PluginPolicy
+
+
+class StaticCredentials:
+    """Return deterministic credentials without reading the environment."""
+
+    def load(self) -> Credentials:
+        """Return a non-secret test credential."""
+        return Credentials("test-key", "test")
+
+
+def test_codex_plugin_is_read_only_by_default() -> None:
+    plugin = CodexPlugin(StaticCredentials())
+
+    names = {tool.name for tool in plugin.tools().list()}
+
+    assert names == {
+        "permutive_get_cohort",
+        "permutive_get_workspace",
+        "permutive_list_cohorts",
+        "permutive_list_segments",
+    }
+    assert plugin.tools().capabilities()["write_tools"] == 0
+
+
+def test_codex_plugin_can_expose_curated_write_tools() -> None:
+    plugin = CodexPlugin(
+        StaticCredentials(),
+        policy=PluginPolicy(mode="read_write"),
+    )
+
+    names = {tool.name for tool in plugin.tools().list()}
+
+    assert "permutive_create_cohort" in names
+    assert "permutive_update_cohort" in names
+    assert plugin.tools().capabilities()["write_tools"] == 2
+
+
+def test_codex_plugin_requires_write_confirmation() -> None:
+    plugin = CodexPlugin(
+        StaticCredentials(),
+        policy=PluginPolicy(mode="read_write"),
+    )
+
+    try:
+        plugin.invoke("permutive_create_cohort", {"payload": {}})
+    except PermissionError as exc:
+        assert "explicit confirmation" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("write tool executed without confirmation")
+
+
+def test_codex_plugin_supports_allow_list() -> None:
+    plugin = CodexPlugin(
+        StaticCredentials(),
+        policy=PluginPolicy(
+            allowed_tools=frozenset({"permutive_get_cohort"}),
+        ),
+    )
+
+    assert [tool.name for tool in plugin.tools().list()] == [
+        "permutive_get_cohort"
+    ]
+
+
+def test_codex_plugin_validation_and_metadata_are_explicit() -> None:
+    plugin = CodexPlugin(StaticCredentials())
+
+    report = plugin.validate()
+
+    assert report.valid
+    assert "credentials" in report.checks
+    assert plugin.metadata.plugin_version == "1.0"
+    assert plugin.metadata.api_version == "1"
+    assert plugin.agent_kit().capabilities()["tool_count"] == 4


### PR DESCRIPTION
## What changed

- consolidates the Codex integration behind one `CodexPlugin` facade
- adds an explicit read-only/read-write policy with tool allow-listing
- requires explicit confirmation before write-tool execution
- exposes a curated set of cohort, segment, and workspace tools through the existing framework-neutral registry
- assembles the SDK tools and official hosted MCP configuration through `agent_kit()`
- adds secret-safe validation, diagnostics, lifecycle cleanup, and explicit plugin/API/SDK version metadata
- strengthens entry-point discovery with duplicate-name and API-version checks
- adds focused contract tests for defaults, writes, confirmation, allow-listing, validation, and metadata

## Why

The previous plugin entry point created a client but did not assemble the existing client, tool registry, agent kit, MCP configuration, safety policy, or lifecycle into an immediately useful integration. This keeps the surface small while making it complete and safe by default.

## Developer impact

The default remains read-only. A complete integration is now available through:

```python
plugin = CodexPlugin.from_env()
plugin.tools().as_openai_tools()
plugin.agent_kit()
plugin.diagnostics()
```

Write tools require `mode="read_write"` and explicit confirmation at invocation time.

## Validation

- Added targeted contract tests in `tests/test_codex_plugin_surface.py`.
- Local execution was unavailable in the current environment because outbound DNS access to GitHub is blocked; GitHub CI should run the repository's full pytest, coverage, formatting, docstring, and strict typing checks.