### PR TITLE
Release PermutiveAPI 6.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to PermutiveAPI are documented here. The project follows Semantic Versioning.
 
+## 6.4.1 - 2026-08-05
+
+### Added
+- Opt-in synchronous and asynchronous diagnostic transport wrappers.
+- Framework-neutral structured request lifecycle events with method, safe endpoint, duration, status, request ID, retry attempt, and exception type metadata.
+- Deterministic diagnostics contract tests and a standard-library logging adapter example.
+
+### Security
+- Diagnostic endpoints exclude query strings.
+- Credentials, payloads, and exception messages are never emitted by the diagnostic contract.
+- Diagnostics remain disabled by default and add no runtime dependency.
+
 ## 6.4.0 - 2026-08-05
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PermutiveAPI"
-version = "6.4.0"
+version = "6.4.1"
 description = "A typed Python SDK for the Permutive API."
 readme = "README.md"
 authors = [{ name = "FaTmamBo33", email = "fatmambo33@gmail.com" }]


### PR DESCRIPTION
## Summary
- bump the package version from 6.4.0 to 6.4.1
- document the framework-neutral sync and async diagnostics shipped after 6.4.0
- record the diagnostic redaction guarantees and zero-dependency default

## Merge gate
Formatting, NumPy docstrings, strict Pyright, tests and coverage on Python 3.9–3.13, package build, Twine validation, and clean installation must pass before merge.