### PR TITLE
Fix automatic release publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,40 +2,83 @@ name: Release
 
 on:
   push:
-    tags:
-      - "v*.*.*"
+    branches:
+      - main
+    paths:
+      - pyproject.toml
+      - .github/workflows/release.yml
+  workflow_dispatch:
 
-permissions:
-  contents: read
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: pip
-      - run: python -m pip install --upgrade build twine
-      - run: python -m build
-      - run: python -m twine check dist/*
-      - uses: actions/upload-artifact@v4
-        with:
-          name: distributions
-          path: dist/
-
-  publish:
-    needs: build
+  release:
     runs-on: ubuntu-latest
     environment:
       name: pypi
       url: https://pypi.org/project/PermutiveAPI/
     permissions:
+      contents: write
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v4
         with:
-          name: distributions
-          path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Resolve release version
+        id: version
+        shell: bash
+        run: |
+          version="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Check whether release already exists
+        id: existing
+        shell: bash
+        run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "released=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "released=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install build tooling
+        if: steps.existing.outputs.released != 'true'
+        run: python -m pip install --upgrade build twine
+
+      - name: Build distributions
+        if: steps.existing.outputs.released != 'true'
+        run: python -m build
+
+      - name: Validate distributions
+        if: steps.existing.outputs.released != 'true'
+        run: python -m twine check dist/*
+
+      - name: Publish to PyPI
+        if: steps.existing.outputs.released != 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create tag and GitHub release
+        if: steps.existing.outputs.released != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" "$GITHUB_SHA" -m "PermutiveAPI ${{ steps.version.outputs.version }}"
+          git push origin "$TAG"
+          gh release create "$TAG" --target "$GITHUB_SHA" --generate-notes --title "$TAG"
+
+      - name: Report existing release
+        if: steps.existing.outputs.released == 'true'
+        run: echo "${{ steps.version.outputs.tag }} already exists; skipping publication."


### PR DESCRIPTION
## Summary
- trigger releases from version/workflow changes merged to `main`
- build and validate distributions before publication
- publish through PyPI trusted publishing
- create the matching annotated Git tag and GitHub release after a successful upload
- skip publication when the version tag already exists

This removes the manual-tag deadlock that prevented 6.4.1 from shipping.