### PR TITLE
Fix PyPI release authentication

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,39 +1,13 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-name: Upload Python Package
+name: Legacy PyPI Upload (disabled)
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  deploy:
-
+  disabled:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
-    - name: Build package
-      run: python -m build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      - run: echo "Publication is handled by .github/workflows/release.yml."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,6 @@ jobs:
       url: https://pypi.org/project/PermutiveAPI/
     permissions:
       contents: write
-      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -65,6 +64,9 @@ jobs:
       - name: Publish to PyPI
         if: steps.existing.outputs.released != 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
 
       - name: Create tag and GitHub release
         if: steps.existing.outputs.released != 'true'


### PR DESCRIPTION
## Summary
- use the repository's configured `PYPI_API_TOKEN` for publication
- remove the invalid trusted-publisher dependency
- disable the duplicate release-triggered upload workflow
- keep tag and GitHub release creation after a successful PyPI upload

This addresses the `invalid-publisher` failure from the 6.4.1 release run.