### PR TITLE
feat: make PermutiveAPI a native Codex plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "fatmambot33-permutiveapi",
+  "interface": {
+    "displayName": "PermutiveAPI"
+  },
+  "plugins": [
+    {
+      "name": "permutiveapi",
+      "source": {
+        "source": "local",
+        "path": "./plugins/permutiveapi"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/plugins/permutiveapi/.codex-plugin/plugin.json
+++ b/plugins/permutiveapi/.codex-plugin/plugin.json
@@ -1,0 +1,30 @@
+{
+  "name": "permutiveapi",
+  "version": "6.4.1",
+  "description": "Use the typed Permutive API SDK safely from Codex.",
+  "author": {
+    "name": "FaTmamBo33",
+    "email": "fatmambo33@gmail.com",
+    "url": "https://github.com/fatmambot33"
+  },
+  "homepage": "https://github.com/fatmambot33/PermutiveAPI",
+  "repository": "https://github.com/fatmambot33/PermutiveAPI",
+  "license": "MIT",
+  "keywords": ["permutive", "api", "sdk", "codex", "python"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "PermutiveAPI",
+    "shortDescription": "Typed Permutive workflows for Codex",
+    "longDescription": "Install and use PermutiveAPI from Git, inspect cohorts and segments, and make confirmed write operations through its safe typed plugin surface.",
+    "developerName": "FaTmamBo33",
+    "category": "Developer Tools",
+    "capabilities": ["Read", "Write", "Interactive"],
+    "websiteURL": "https://github.com/fatmambot33/PermutiveAPI",
+    "defaultPrompt": [
+      "Inspect my Permutive workspace safely.",
+      "List cohorts and explain their configuration.",
+      "Prepare a confirmed Permutive API change."
+    ],
+    "brandColor": "#2563EB"
+  }
+}

--- a/plugins/permutiveapi/skills/permutiveapi/SKILL.md
+++ b/plugins/permutiveapi/skills/permutiveapi/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: permutiveapi
+description: Install and use PermutiveAPI from Git for typed, safe Permutive workflows. Use for workspace inspection, cohorts, segments, imports, sources, diagnostics, and confirmed write operations.
+---
+
+# PermutiveAPI
+
+## Setup
+
+Ensure the current Python environment has the repository version installed:
+
+```bash
+python -m pip install --upgrade "git+https://github.com/fatmambot33/PermutiveAPI.git"
+```
+
+Use `PermutiveAPI.plugins.codex.CodexPlugin` as the primary integration surface. Start read-only. Enable write mode only when the user explicitly requests a mutation, and require confirmation immediately before executing it.
+
+## Workflow
+
+1. Check configuration and credentials without printing secrets.
+2. Run plugin diagnostics before API work.
+3. Prefer typed SDK methods and plugin-provided tools over raw HTTP.
+4. Inspect before changing.
+5. For writes, present the exact intended change and obtain confirmation.
+6. Report API errors with secrets and tokens redacted.
+
+## Examples
+
+```python
+from PermutiveAPI.plugins.codex import CodexPlugin
+
+plugin = CodexPlugin.from_env()
+print(plugin.diagnostics())
+tools = plugin.tools()
+```
+
+Keep outputs concise and include object identifiers needed for follow-up work.


### PR DESCRIPTION
## Summary

- add a repo-backed Codex marketplace
- add a validated `.codex-plugin/plugin.json` manifest
- add a reusable PermutiveAPI skill
- provide Git installation and safe read/write workflow guidance

## Install

```bash
codex plugin marketplace add fatmambot33/PermutiveAPI --ref main
codex plugin add permutiveapi@fatmambot33-permutiveapi
```
