### PR TITLE
feat: add local credential configure and doctor commands

### DIFF
--- a/plugins/permutiveapi/skills/permutiveapi/SKILL.md
+++ b/plugins/permutiveapi/skills/permutiveapi/SKILL.md
@@ -7,31 +7,9 @@ description: Install and use PermutiveAPI from Git with credentials loaded only 
 
 ## Local-only credential policy
 
-Use only credentials stored in the user's local project `.env`. Never request, upload, persist, or copy secrets into Codex, Git, plugin files, chat messages, hosted configuration, MCP URLs, or command history. Never print credential values.
+Use only credentials stored in the user's local project `.env`. Never request secret values in chat, upload them, print them, or copy them into Codex, Git, plugin files, hosted configuration, MCP URLs, or command history.
 
-Before the first API operation:
-
-1. Check whether `.env` exists in the current working directory.
-2. If it is missing, copy the included template:
-
-```bash
-cp plugins/permutiveapi/.env.example .env
-```
-
-3. Ask the user to edit `.env` locally and provide values for:
-
-```dotenv
-PERMUTIVE_API_KEY=
-PERMUTIVE_WORKSPACE_ID=
-```
-
-4. Ensure `.env` is ignored by Git. Add it to `.gitignore` when necessary.
-5. Verify only that required variables are present and non-empty. Report missing variable names, never their values.
-6. Stop before making API calls until local configuration is complete.
-
-Load the local file with `python-dotenv` or the package's `from_env()` path. Do not fall back to hosted secrets, Codex-managed credentials, remote secret stores, or credentials supplied in prompts.
-
-## Setup
+## First-use setup
 
 Install the repository version locally:
 
@@ -39,18 +17,39 @@ Install the repository version locally:
 python -m pip install --upgrade "git+https://github.com/fatmambot33/PermutiveAPI.git"
 ```
 
-Use `PermutiveAPI.plugins.codex.CodexPlugin` as the primary integration surface. Start read-only. Enable write mode only for an explicitly requested mutation and require confirmation immediately before execution.
+Before every API workflow, run:
+
+```bash
+permutiveapi doctor
+```
+
+When the check fails, guide the user through the local interactive wizard:
+
+```bash
+permutiveapi configure
+```
+
+The wizard:
+
+1. Prompts for the API key without echoing it.
+2. Prompts for the workspace ID.
+3. Writes only to the current project's `.env`.
+4. Uses restrictive file permissions where supported.
+5. Refuses to overwrite an existing file unless `--force` is supplied.
+6. Warns when `.env` is not ignored by Git.
+
+Run `permutiveapi doctor` again after configuration. It verifies the file, required variable names, permissions, and Git-ignore protection without displaying values. Stop before API calls until it passes.
+
+Use `--env-file PATH` for a deliberate non-default local file. Do not fall back to hosted secrets, Codex-managed credentials, remote secret stores, or prompt-supplied credentials.
 
 ## Workflow
 
-1. Complete the local `.env` check and configuration guidance.
-2. Run diagnostics without printing secrets.
-3. Prefer typed SDK methods and plugin tools over raw HTTP.
-4. Inspect before changing.
-5. Present the exact intended mutation and obtain confirmation for writes.
-6. Redact tokens, credentials, and authorization headers from every output and error.
-
-## Example
+1. Run `permutiveapi doctor`.
+2. Run plugin diagnostics without printing secrets.
+3. Use `PermutiveAPI.plugins.codex.CodexPlugin` and typed tools.
+4. Start read-only and inspect before changing.
+5. Present the exact mutation and obtain confirmation for writes.
+6. Redact authorization data from every output and error.
 
 ```python
 from dotenv import load_dotenv
@@ -60,5 +59,3 @@ load_dotenv(".env")
 plugin = CodexPlugin.from_env()
 print(plugin.diagnostics())
 ```
-
-Keep outputs concise and include only non-secret object identifiers needed for follow-up work.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
+[project.scripts]
+permutiveapi = "PermutiveAPI.cli:main"
+
 [project.entry-points."permutiveapi.plugins"]
 codex = "PermutiveAPI.plugins.codex:CodexPlugin"
 
@@ -80,6 +83,7 @@ include = [
     "src/PermutiveAPI/__init__.py",
     "src/PermutiveAPI/agent.py",
     "src/PermutiveAPI/async_client.py",
+    "src/PermutiveAPI/cli.py",
     "src/PermutiveAPI/client.py",
     "src/PermutiveAPI/config.py",
     "src/PermutiveAPI/credentials.py",

--- a/src/PermutiveAPI/cli.py
+++ b/src/PermutiveAPI/cli.py
@@ -6,7 +6,7 @@ import argparse
 import getpass
 import os
 from pathlib import Path
-from typing import Dict, Iterable, Optional, Sequence
+from typing import Dict, Optional, Sequence
 
 from dotenv import dotenv_values
 

--- a/src/PermutiveAPI/cli.py
+++ b/src/PermutiveAPI/cli.py
@@ -1,0 +1,118 @@
+"""Local-only credential setup commands for PermutiveAPI."""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import os
+from pathlib import Path
+from typing import Dict, Iterable, Optional, Sequence
+
+from dotenv import dotenv_values
+
+REQUIRED_VARIABLES = ("PERMUTIVE_API_KEY", "PERMUTIVE_WORKSPACE_ID")
+
+
+def _is_ignored(env_path: Path) -> bool:
+    """Return whether a nearby gitignore explicitly ignores ``.env``."""
+    for parent in (env_path.parent, *env_path.parents):
+        gitignore = parent / ".gitignore"
+        if gitignore.is_file():
+            entries = {
+                line.strip()
+                for line in gitignore.read_text(encoding="utf-8").splitlines()
+                if line.strip() and not line.lstrip().startswith("#")
+            }
+            return ".env" in entries or "*.env" in entries
+        if (parent / ".git").exists():
+            break
+    return False
+
+
+def _write_env(path: Path, values: Dict[str, str]) -> None:
+    """Write credentials to a local file with restrictive permissions."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = "".join(f"{name}={value}\n" for name, value in values.items())
+    path.write_text(content, encoding="utf-8")
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+
+
+def configure(env_file: Path, *, force: bool = False) -> int:
+    """Interactively create a local credential file without echoing secrets."""
+    if env_file.exists() and not force:
+        print(f"Refusing to overwrite {env_file}. Use --force to replace it.")
+        return 2
+
+    print("PermutiveAPI local credential setup")
+    print("Credentials remain in this local .env file and are never uploaded.")
+    values = {
+        "PERMUTIVE_API_KEY": getpass.getpass("Permutive API key: ").strip(),
+        "PERMUTIVE_WORKSPACE_ID": input("Permutive workspace ID: ").strip(),
+    }
+    missing = [name for name, value in values.items() if not value]
+    if missing:
+        print("Missing required values: " + ", ".join(missing))
+        return 2
+
+    _write_env(env_file, values)
+    print(f"Created {env_file} with local-only permissions where supported.")
+    if not _is_ignored(env_file):
+        print("WARNING: add .env to the repository .gitignore before committing.")
+        return 1
+    print("Credential setup complete. Run `permutiveapi doctor` to verify it.")
+    return 0
+
+
+def doctor(env_file: Path) -> int:
+    """Validate local credential setup without exposing secret values."""
+    problems = []
+    if not env_file.is_file():
+        problems.append(f"missing credential file: {env_file}")
+        values: Dict[str, Optional[str]] = {}
+    else:
+        values = dict(dotenv_values(env_file))
+        missing = [name for name in REQUIRED_VARIABLES if not values.get(name)]
+        if missing:
+            problems.append("missing variables: " + ", ".join(missing))
+        if os.name != "nt" and env_file.stat().st_mode & 0o077:
+            problems.append("credential file permissions are too broad; run chmod 600 .env")
+    if not _is_ignored(env_file):
+        problems.append(".env is not explicitly ignored by .gitignore")
+
+    if problems:
+        print("PermutiveAPI credential check failed:")
+        for problem in problems:
+            print(f"- {problem}")
+        print("Run `permutiveapi configure` to repair local configuration.")
+        return 1
+
+    print("PermutiveAPI local credential check passed.")
+    print("Required variables are present; values were not displayed.")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(prog="permutiveapi")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    configure_parser = subparsers.add_parser("configure")
+    configure_parser.add_argument("--env-file", type=Path, default=Path(".env"))
+    configure_parser.add_argument("--force", action="store_true")
+    doctor_parser = subparsers.add_parser("doctor")
+    doctor_parser.add_argument("--env-file", type=Path, default=Path(".env"))
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Run the PermutiveAPI command-line interface."""
+    args = build_parser().parse_args(argv)
+    if args.command == "configure":
+        return configure(args.env_file, force=args.force)
+    return doctor(args.env_file)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add `permutiveapi configure` interactive local credential setup
- add `permutiveapi doctor` secret-free validation
- protect existing `.env` files from accidental overwrite
- validate required variables, file permissions, and `.gitignore` coverage
- update the Codex skill to run the doctor before API workflows

Credentials are never printed or uploaded.