### PR TITLE
feat: make PermutiveAPI an AI-native governed platform

### DIFF
--- a/docs/AI_NATIVE.md
+++ b/docs/AI_NATIVE.md
@@ -1,0 +1,101 @@
+# PermutiveAPI AI-Native Platform
+
+PermutiveAPI 6.5 turns the SDK, plugin surface, and MCP configuration into one governed agent platform.
+
+## Platform contract
+
+The platform exposes five stable layers:
+
+1. **Typed SDK** — deterministic Python resources and models.
+2. **Tool registry** — framework-neutral JSON Schema tools for OpenAI-compatible runtimes and plugins.
+3. **Governed executor** — policy checks, write approval, structured failures, audit hooks, and idempotency.
+4. **Workflow runner** — bounded multi-step execution with deterministic ordering and safe stop-on-error behavior.
+5. **MCP bridge** — portable configuration for Permutive's official hosted MCP server.
+
+No model provider is required by the core package. Agents may use OpenAI, Codex, MCP clients, or any runtime capable of calling JSON Schema tools.
+
+## Safe by default
+
+Mutating tools require explicit approval unless the execution policy says otherwise.
+
+```python
+from PermutiveAPI import PermutiveAgentKit
+from PermutiveAPI.ai_native import WorkflowStep
+
+kit = PermutiveAgentKit(tools=registry)
+
+result = kit.run_workflow(
+    [
+        WorkflowStep(
+            name="inspect-workspace",
+            tool_name="workspace_get",
+            arguments={"workspace_id": "workspace-id"},
+        ),
+        WorkflowStep(
+            name="create-cohort",
+            tool_name="cohort_create",
+            arguments={"name": "High intent"},
+            approved=True,
+        ),
+    ],
+    run_id="campaign-2026-08-05",
+)
+```
+
+## Execution policy
+
+`ExecutionPolicy` supports:
+
+- tool allow-lists;
+- explicit deny-lists;
+- approval for all calls, writes only, or no calls;
+- a hard maximum workflow length.
+
+A denied or unapproved call fails before the handler is invoked.
+
+## Structured execution results
+
+Every governed call returns `InvocationResult` rather than leaking runtime-specific exceptions across the agent boundary. Results contain:
+
+- tool and run identifiers;
+- success state;
+- output or normalized failure details;
+- UTC start and finish timestamps;
+- the idempotency key used for safe retry.
+
+## Idempotency
+
+Successful calls with the same idempotency key return the completed result without invoking the handler again. Workflow keys are derived deterministically from the run identifier, step index, tool name, and arguments.
+
+This protects agents from duplicate writes after transport retries or model replays.
+
+## Auditability
+
+Pass an `audit_sink` callback to `PermutiveAgentKit` or `GovernedToolExecutor`. The callback receives each completed invocation result and can forward it to structured logs, OpenTelemetry, a data warehouse, or an approval ledger.
+
+Secrets must never be placed in tool arguments, metadata, outputs, or audit logs.
+
+## Machine discovery
+
+`PermutiveAgentKit.manifest()` returns a portable manifest describing:
+
+- available tools and JSON Schemas;
+- read/write classification;
+- capability tags;
+- governance features;
+- MCP configuration status.
+
+Agents can inspect the manifest before planning, avoiding unsupported operations and reducing unnecessary tool calls.
+
+## Production requirements
+
+A production deployment should:
+
+- use stable tool names and backward-compatible schemas;
+- keep write approval enabled;
+- attach a durable audit sink;
+- provide a unique run ID per user goal;
+- reuse idempotency keys when retrying the same action;
+- set an allow-list for narrowly scoped agents;
+- keep credentials in environment variables or a secret manager;
+- run the complete test, type-check, documentation, and package-build gates.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "PermutiveAPI"
-version = "6.4.1"
-description = "A typed Python SDK for the Permutive API."
+version = "6.5.0"
+description = "A typed, governed AI-native Python platform for the Permutive API."
 readme = "README.md"
 authors = [{ name = "FaTmamBo33", email = "fatmambo33@gmail.com" }]
 license = { file = "LICENSE" }
@@ -82,6 +82,7 @@ line-length = 88
 include = [
     "src/PermutiveAPI/__init__.py",
     "src/PermutiveAPI/agent.py",
+    "src/PermutiveAPI/ai_native.py",
     "src/PermutiveAPI/async_client.py",
     "src/PermutiveAPI/cli.py",
     "src/PermutiveAPI/client.py",

--- a/src/PermutiveAPI/agent.py
+++ b/src/PermutiveAPI/agent.py
@@ -2,14 +2,25 @@
 
 from __future__ import annotations
 
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
+from .ai_native import (
+    AgentWorkflowRunner,
+    AuditSink,
+    ExecutionPolicy,
+    GovernedToolExecutor,
+    InvocationContext,
+    InvocationResult,
+    WorkflowResult,
+    WorkflowStep,
+    platform_manifest,
+)
 from .mcp import PermutiveMCPConfig
 from .tools import ToolRegistry
 
 
 class PermutiveAgentKit:
-    """Bundle SDK tools and hosted MCP configuration for agent runtimes.
+    """Bundle tools, governance, workflows, and MCP for agent runtimes.
 
     Parameters
     ----------
@@ -17,6 +28,10 @@ class PermutiveAgentKit:
         Framework-neutral tool registry.
     mcp
         Optional connection to Permutive's official hosted MCP server.
+    policy
+        Execution policy controlling access and approvals.
+    audit_sink
+        Optional callback receiving every completed invocation.
     """
 
     def __init__(
@@ -24,15 +39,40 @@ class PermutiveAgentKit:
         tools: ToolRegistry | None = None,
         *,
         mcp: PermutiveMCPConfig | None = None,
+        policy: ExecutionPolicy | None = None,
+        audit_sink: AuditSink | None = None,
     ) -> None:
         self.tools = tools or ToolRegistry()
         self.mcp = mcp
+        self.executor = GovernedToolExecutor(
+            self.tools,
+            policy=policy,
+            audit_sink=audit_sink,
+        )
+        self.workflows = AgentWorkflowRunner(self.executor)
 
     def capabilities(self) -> dict[str, Any]:
         """Return machine-readable capabilities for adaptive agents."""
         capabilities = self.tools.capabilities()
-        capabilities["official_mcp"] = self.mcp is not None
+        capabilities.update(
+            {
+                "official_mcp": self.mcp is not None,
+                "governed_execution": True,
+                "workflow_runner": True,
+                "idempotency": True,
+                "structured_results": True,
+            }
+        )
         return capabilities
+
+    def manifest(self) -> dict[str, Any]:
+        """Return the portable AI-native platform manifest."""
+        manifest = platform_manifest(self.tools)
+        manifest["mcp"] = {
+            "configured": self.mcp is not None,
+            "client_config": self.mcp_config(),
+        }
+        return manifest
 
     def openai_tools(self) -> list[dict[str, Any]]:
         """Export local tools in OpenAI-compatible function format."""
@@ -46,9 +86,33 @@ class PermutiveAgentKit:
         self,
         name: str,
         arguments: Mapping[str, Any] | None = None,
-    ) -> Any:
-        """Execute a local tool call returned by an agent runtime."""
-        return self.tools.invoke(name, arguments)
+        *,
+        run_id: str = "interactive",
+        actor: str = "agent",
+        approved: bool = False,
+        idempotency_key: str | None = None,
+    ) -> InvocationResult:
+        """Execute a governed local tool call returned by an agent runtime."""
+        return self.executor.invoke(
+            name,
+            arguments,
+            context=InvocationContext(
+                run_id=run_id,
+                actor=actor,
+                approved=approved,
+                idempotency_key=idempotency_key,
+            ),
+        )
+
+    def run_workflow(
+        self,
+        steps: Sequence[WorkflowStep],
+        *,
+        run_id: str,
+        actor: str = "agent",
+    ) -> WorkflowResult:
+        """Execute a bounded, governed multi-step workflow."""
+        return self.workflows.run(steps, run_id=run_id, actor=actor)
 
 
 __all__ = ["PermutiveAgentKit"]

--- a/src/PermutiveAPI/ai_native.py
+++ b/src/PermutiveAPI/ai_native.py
@@ -1,0 +1,300 @@
+"""Governed execution primitives for AI-native Permutive workflows."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Callable, Mapping, Sequence
+
+from .tools import ToolDefinition, ToolRegistry
+
+
+class ApprovalMode(str, Enum):
+    """Control whether mutating tools require explicit approval."""
+
+    NEVER = "never"
+    WRITES = "writes"
+    ALWAYS = "always"
+
+
+@dataclass(frozen=True)
+class ExecutionPolicy:
+    """Define safety and governance rules for agent tool execution.
+
+    Parameters
+    ----------
+    approval_mode
+        Approval requirement applied before tool execution.
+    allowed_tools
+        Optional allow-list of stable tool names.
+    denied_tools
+        Explicit deny-list evaluated before the allow-list.
+    max_steps
+        Maximum number of workflow steps per run.
+    """
+
+    approval_mode: ApprovalMode = ApprovalMode.WRITES
+    allowed_tools: frozenset[str] | None = None
+    denied_tools: frozenset[str] = field(default_factory=frozenset)
+    max_steps: int = 25
+
+    def __post_init__(self) -> None:
+        if self.max_steps < 1:
+            raise ValueError("max_steps must be at least 1.")
+        if self.allowed_tools is not None and self.denied_tools & self.allowed_tools:
+            raise ValueError("A tool cannot be both allowed and denied.")
+
+    def check(self, tool: ToolDefinition, *, approved: bool) -> None:
+        """Validate whether a tool may execute under this policy."""
+        if tool.name in self.denied_tools:
+            raise PermissionError(f"Tool is denied by policy: {tool.name}")
+        if self.allowed_tools is not None and tool.name not in self.allowed_tools:
+            raise PermissionError(f"Tool is not allowed by policy: {tool.name}")
+
+        requires_approval = self.approval_mode is ApprovalMode.ALWAYS or (
+            self.approval_mode is ApprovalMode.WRITES and not tool.read_only
+        )
+        if requires_approval and not approved:
+            raise PermissionError(f"Tool requires explicit approval: {tool.name}")
+
+
+@dataclass(frozen=True)
+class InvocationContext:
+    """Carry execution metadata across agent and workflow calls."""
+
+    run_id: str
+    actor: str = "agent"
+    approved: bool = False
+    idempotency_key: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class InvocationResult:
+    """Return a structured, auditable result from a tool invocation."""
+
+    tool_name: str
+    run_id: str
+    ok: bool
+    output: Any = None
+    error_type: str | None = None
+    error_message: str | None = None
+    started_at: str = ""
+    finished_at: str = ""
+    idempotency_key: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return {
+            "tool_name": self.tool_name,
+            "run_id": self.run_id,
+            "ok": self.ok,
+            "output": self.output,
+            "error_type": self.error_type,
+            "error_message": self.error_message,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "idempotency_key": self.idempotency_key,
+        }
+
+
+AuditSink = Callable[[InvocationResult], None]
+
+
+class GovernedToolExecutor:
+    """Execute registered tools with policy, audit, and idempotency controls."""
+
+    def __init__(
+        self,
+        registry: ToolRegistry,
+        *,
+        policy: ExecutionPolicy | None = None,
+        audit_sink: AuditSink | None = None,
+    ) -> None:
+        self.registry = registry
+        self.policy = policy or ExecutionPolicy()
+        self.audit_sink = audit_sink
+        self._completed: dict[str, InvocationResult] = {}
+
+    def invoke(
+        self,
+        name: str,
+        arguments: Mapping[str, Any] | None,
+        *,
+        context: InvocationContext,
+    ) -> InvocationResult:
+        """Execute one tool and always return a structured result."""
+        tool = self.registry.get(name)
+        self.policy.check(tool, approved=context.approved)
+
+        key = context.idempotency_key
+        if key is not None and key in self._completed:
+            return self._completed[key]
+
+        started_at = datetime.now(timezone.utc).isoformat()
+        try:
+            output = tool.invoke(arguments)
+            result = InvocationResult(
+                tool_name=name,
+                run_id=context.run_id,
+                ok=True,
+                output=output,
+                started_at=started_at,
+                finished_at=datetime.now(timezone.utc).isoformat(),
+                idempotency_key=key,
+            )
+        except Exception as exc:  # noqa: BLE001 - boundary converts failures to data
+            result = InvocationResult(
+                tool_name=name,
+                run_id=context.run_id,
+                ok=False,
+                error_type=type(exc).__name__,
+                error_message=str(exc),
+                started_at=started_at,
+                finished_at=datetime.now(timezone.utc).isoformat(),
+                idempotency_key=key,
+            )
+
+        if key is not None and result.ok:
+            self._completed[key] = result
+        if self.audit_sink is not None:
+            self.audit_sink(result)
+        return result
+
+
+@dataclass(frozen=True)
+class WorkflowStep:
+    """Describe one deterministic tool call in an agent workflow."""
+
+    name: str
+    tool_name: str
+    arguments: Mapping[str, Any] = field(default_factory=dict)
+    approved: bool = False
+    continue_on_error: bool = False
+
+
+@dataclass(frozen=True)
+class WorkflowResult:
+    """Summarize a completed governed workflow run."""
+
+    run_id: str
+    ok: bool
+    steps: tuple[InvocationResult, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable workflow result."""
+        return {
+            "run_id": self.run_id,
+            "ok": self.ok,
+            "steps": [step.to_dict() for step in self.steps],
+        }
+
+
+class AgentWorkflowRunner:
+    """Run bounded, deterministic workflows over the governed tool surface."""
+
+    def __init__(self, executor: GovernedToolExecutor) -> None:
+        self.executor = executor
+
+    def run(
+        self,
+        steps: Sequence[WorkflowStep],
+        *,
+        run_id: str,
+        actor: str = "agent",
+    ) -> WorkflowResult:
+        """Execute workflow steps in order and stop safely on failure."""
+        if len(steps) > self.executor.policy.max_steps:
+            raise ValueError("Workflow exceeds the configured max_steps limit.")
+
+        results: list[InvocationResult] = []
+        for index, step in enumerate(steps):
+            key = _workflow_idempotency_key(run_id, index, step)
+            result = self.executor.invoke(
+                step.tool_name,
+                step.arguments,
+                context=InvocationContext(
+                    run_id=run_id,
+                    actor=actor,
+                    approved=step.approved,
+                    idempotency_key=key,
+                    metadata={"step": step.name, "index": index},
+                ),
+            )
+            results.append(result)
+            if not result.ok and not step.continue_on_error:
+                break
+
+        return WorkflowResult(
+            run_id=run_id,
+            ok=bool(results) and all(result.ok for result in results),
+            steps=tuple(results),
+        )
+
+
+def platform_manifest(
+    registry: ToolRegistry,
+    *,
+    name: str = "PermutiveAPI",
+    version: str = "1",
+) -> dict[str, Any]:
+    """Build a portable machine-readable AI platform manifest."""
+    return {
+        "name": name,
+        "version": version,
+        "capabilities": registry.capabilities(),
+        "tools": [
+            {
+                "name": item.name,
+                "description": item.description,
+                "input_schema": item.input_schema,
+                "tags": list(item.tags),
+                "read_only": item.read_only,
+            }
+            for item in registry.list()
+        ],
+        "governance": {
+            "approval_modes": [mode.value for mode in ApprovalMode],
+            "idempotency": True,
+            "structured_results": True,
+            "bounded_workflows": True,
+            "audit_sink": True,
+        },
+    }
+
+
+def _workflow_idempotency_key(
+    run_id: str,
+    index: int,
+    step: WorkflowStep,
+) -> str:
+    payload = json.dumps(
+        {
+            "run_id": run_id,
+            "index": index,
+            "name": step.name,
+            "tool_name": step.tool_name,
+            "arguments": step.arguments,
+        },
+        sort_keys=True,
+        default=str,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "AgentWorkflowRunner",
+    "ApprovalMode",
+    "AuditSink",
+    "ExecutionPolicy",
+    "GovernedToolExecutor",
+    "InvocationContext",
+    "InvocationResult",
+    "WorkflowResult",
+    "WorkflowStep",
+    "platform_manifest",
+]

--- a/tests/test_ai_native.py
+++ b/tests/test_ai_native.py
@@ -1,0 +1,126 @@
+"""Tests for governed AI-native execution primitives."""
+
+from __future__ import annotations
+
+from PermutiveAPI.ai_native import (
+    AgentWorkflowRunner,
+    ApprovalMode,
+    ExecutionPolicy,
+    GovernedToolExecutor,
+    InvocationContext,
+    WorkflowStep,
+    platform_manifest,
+)
+from PermutiveAPI.tools import ToolDefinition, ToolRegistry
+
+
+def _registry() -> ToolRegistry:
+    state = {"writes": 0}
+
+    def read_value(value: int = 1) -> int:
+        return value
+
+    def write_value(value: int) -> dict[str, int]:
+        state["writes"] += 1
+        return {"value": value, "writes": state["writes"]}
+
+    return ToolRegistry(
+        [
+            ToolDefinition(
+                name="read_value",
+                description="Read a value.",
+                input_schema={"type": "object", "properties": {}},
+                handler=read_value,
+                tags=("read",),
+            ),
+            ToolDefinition(
+                name="write_value",
+                description="Write a value.",
+                input_schema={
+                    "type": "object",
+                    "properties": {"value": {"type": "integer"}},
+                    "required": ["value"],
+                    "additionalProperties": False,
+                },
+                handler=write_value,
+                tags=("write",),
+                read_only=False,
+            ),
+        ]
+    )
+
+
+def test_write_tools_require_approval_by_default() -> None:
+    executor = GovernedToolExecutor(_registry())
+
+    try:
+        executor.invoke(
+            "write_value",
+            {"value": 3},
+            context=InvocationContext(run_id="run-1"),
+        )
+    except PermissionError as exc:
+        assert "explicit approval" in str(exc)
+    else:
+        raise AssertionError("Expected write approval to be enforced.")
+
+
+def test_idempotency_returns_completed_result_without_duplicate_write() -> None:
+    executor = GovernedToolExecutor(_registry())
+    context = InvocationContext(
+        run_id="run-2",
+        approved=True,
+        idempotency_key="stable-key",
+    )
+
+    first = executor.invoke("write_value", {"value": 4}, context=context)
+    second = executor.invoke("write_value", {"value": 99}, context=context)
+
+    assert first is second
+    assert first.output == {"value": 4, "writes": 1}
+
+
+def test_workflow_stops_after_failure() -> None:
+    registry = _registry()
+
+    def fail() -> None:
+        raise RuntimeError("boom")
+
+    registry.register(
+        ToolDefinition(
+            name="fail",
+            description="Fail deliberately.",
+            input_schema={"type": "object", "properties": {}},
+            handler=fail,
+        )
+    )
+    runner = AgentWorkflowRunner(
+        GovernedToolExecutor(
+            registry,
+            policy=ExecutionPolicy(approval_mode=ApprovalMode.NEVER),
+        )
+    )
+
+    result = runner.run(
+        [
+            WorkflowStep(name="first", tool_name="read_value"),
+            WorkflowStep(name="failure", tool_name="fail"),
+            WorkflowStep(name="never", tool_name="read_value"),
+        ],
+        run_id="run-3",
+    )
+
+    assert result.ok is False
+    assert len(result.steps) == 2
+    assert result.steps[-1].error_type == "RuntimeError"
+
+
+def test_manifest_is_machine_readable_and_governed() -> None:
+    manifest = platform_manifest(_registry())
+
+    assert manifest["capabilities"]["tool_count"] == 2
+    assert manifest["governance"]["idempotency"] is True
+    assert {tool["name"] for tool in manifest["tools"]} == {
+        "read_value",
+        "write_value",
+    }

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -79,6 +79,12 @@ def test_agent_kit_reports_local_and_mcp_capabilities() -> None:
         "write_tools": 0,
         "tags": [],
         "official_mcp": True,
+        "governed_execution": True,
+        "workflow_runner": True,
+        "idempotency": True,
+        "structured_results": True,
     }
-    assert kit.invoke("increment", {"value": 8}) == 9
+    result = kit.invoke("increment", {"value": 8})
+    assert result.ok
+    assert result.output == 9
     assert kit.mcp_config() == mcp.to_client_config()


### PR DESCRIPTION
## Summary

Promotes PermutiveAPI from an agent-compatible SDK to a governed AI-native platform.

### Platform capabilities

- governed tool execution with allow/deny policies
- explicit approval gates for mutating tools by default
- structured invocation results and normalized failures
- deterministic idempotency for safe retries
- bounded multi-step workflow runner
- audit sink integration
- machine-readable platform manifest
- unified AgentKit access across tools, workflows, and hosted MCP
- production contract documentation

### Release

Prepares version `6.5.0` as the first AI-native platform release.

### Validation

- dedicated policy, idempotency, workflow, and manifest tests
- strict Pyright coverage extended to the new module
- existing CI remains the merge gate
