### PR TITLE
chore: adopt canonical AI-native platform standard

### DIFF
--- a/AI_NATIVE_PLATFORM.yaml
+++ b/AI_NATIVE_PLATFORM.yaml
@@ -1,9 +1,8 @@
 version: 1
 
-platform:
-  name: First Class AI Native Platform
-  required: true
-  standard_repository: fatmambot33/ai-native-platform
+standard:
+  repository: fatmambot33/ai-native-platform
+  ref: d1d8149e148148521cb467799d098e58c3f3a0b9
 
 product:
   name: PermutiveAPI
@@ -28,9 +27,7 @@ plugin:
     local_only: true
     env_file: .env
     env_example: plugins/permutiveapi/.env.example
-    required_variables:
-      - PERMUTIVE_API_KEY
-      - PERMUTIVE_WORKSPACE_ID
+    required_variables: [PERMUTIVE_API_KEY, PERMUTIVE_WORKSPACE_ID]
     setup_command: permutiveapi configure
     validation_command: permutiveapi doctor
     policy:
@@ -41,18 +38,8 @@ plugin:
       require_local_env: true
 
 commands:
-  required:
-    - configure
-    - doctor
-    - validate
-    - test
-    - docs
-    - examples
-    - upgrade
-    - uninstall
-  recommended:
-    - eval
-    - benchmark
+  required: [configure, doctor, validate, test, docs, examples, upgrade, uninstall]
+  recommended: [eval, benchmark]
 
 interfaces:
   sdk: true
@@ -74,41 +61,28 @@ quality:
 
 self_improvement:
   enabled: true
-  github_issues_as_work_queue: true
-  discover_improvements: true
-  create_issues: true
-  agent_ready_issues: true
-  agent_can_open_pull_requests: true
-  run_ci_before_merge: true
-  update_roadmap_and_changelog: true
-  sources:
-    - ci_failures
-    - dependency_updates
-    - release_notes
-    - user_feedback
-    - todos
-    - code_analysis
-    - documentation_gaps
+  github:
+    issues: true
+  autonomous:
+    discover_improvements: true
+    create_issues: true
+    generate_pr: true
+    run_ci: true
+    update_roadmap_and_changelog: true
   governance:
-    human_approval_required:
-      - breaking_changes
-      - security_changes
-      - credential_changes
-      - public_api_changes
-      - release_changes
-    safe_auto_merge:
-      - documentation
-      - tests
-      - formatting
-      - examples
-      - non_breaking_maintenance
+    human_approval:
+      breaking_changes: true
+      security_changes: true
+      credential_changes: true
+      public_api_changes: true
+      release_changes: true
+    safe_auto_merge: [documentation, tests, formatting, examples, non_breaking_maintenance]
 
 release:
   block_if_quality_fails: true
   block_if_doctor_fails: true
   block_if_plugin_invalid: true
   block_if_self_improvement_contract_invalid: true
-  validate_manifest: python scripts/validate_ai_native_platform.py
 
 agent:
   guarantees:
@@ -117,4 +91,6 @@ agent:
     - human_confirmation_for_writes
     - deterministic_tool_discovery
     - structured_outputs
-    - issue_driven_self_improvement
+    - issue_driven_improvement
+    - ci_validated_changes
+    - governed_autonomy


### PR DESCRIPTION
## Summary

- replace the copied platform identity with a pinned reference to `fatmambot33/ai-native-platform`
- align self-improvement declarations with the canonical schema
- require issue-driven improvement, CI-validated changes, and governed autonomy
- preserve local-only credential and human-confirmed write policies

The standard is pinned to an immutable commit for reproducible validation.