### PR TITLE
fix: finish AI-native CI and type the Codex handlers

### DIFF
--- a/src/PermutiveAPI/cli.py
+++ b/src/PermutiveAPI/cli.py
@@ -78,7 +78,9 @@ def doctor(env_file: Path) -> int:
         if missing:
             problems.append("missing variables: " + ", ".join(missing))
         if os.name != "nt" and env_file.stat().st_mode & 0o077:
-            problems.append("credential file permissions are too broad; run chmod 600 .env")
+            problems.append(
+                "credential file permissions are too broad; run chmod 600 .env"
+            )
     if not _is_ignored(env_file):
         problems.append(".env is not explicitly ignored by .gitignore")
 

--- a/src/PermutiveAPI/plugins/codex.py
+++ b/src/PermutiveAPI/plugins/codex.py
@@ -110,40 +110,58 @@ class CodexPlugin:
         return schema
 
     def _definitions(self, client: PermutiveClient) -> tuple[ToolDefinition, ...]:
+        def list_cohorts(page_size: int = 100) -> Any:
+            return client.cohorts.list(page_size=page_size).items
+
+        def get_cohort(resource_id: str) -> Any:
+            return client.cohorts.get(resource_id)
+
+        def list_segments(page_size: int = 100) -> Any:
+            return client.segments.list(page_size=page_size).items
+
+        def get_workspace(resource_id: str) -> Any:
+            return client.workspaces.get(resource_id)
+
+        def create_cohort(payload: JSONObject) -> Any:
+            return client.cohorts.create(payload)
+
+        def update_cohort(resource_id: str, payload: JSONObject) -> Any:
+            return client.cohorts.update(resource_id, payload)
+
         return (
             ToolDefinition(
                 "permutive_list_cohorts",
                 "List Permutive cohorts with bounded pagination.",
                 self._object_schema(),
-                lambda page_size=100: client.cohorts.list(page_size=page_size).items,
+                list_cohorts,
                 ("cohorts", "read"),
             ),
             ToolDefinition(
                 "permutive_get_cohort",
                 "Get one Permutive cohort by identifier.",
                 self._object_schema(required=("resource_id",)),
-                lambda resource_id: client.cohorts.get(resource_id),
+                get_cohort,
                 ("cohorts", "read"),
             ),
             ToolDefinition(
                 "permutive_list_segments",
                 "List Permutive audience segments with bounded pagination.",
                 self._object_schema(),
-                lambda page_size=100: client.segments.list(page_size=page_size).items,
+                list_segments,
                 ("segments", "read"),
             ),
             ToolDefinition(
                 "permutive_get_workspace",
                 "Get one Permutive workspace by identifier.",
                 self._object_schema(required=("resource_id",)),
-                lambda resource_id: client.workspaces.get(resource_id),
+                get_workspace,
                 ("workspaces", "read"),
             ),
             ToolDefinition(
                 "permutive_create_cohort",
                 "Create a Permutive cohort from a JSON payload.",
                 self._object_schema(required=("payload",)),
-                lambda payload: client.cohorts.create(cast(JSONObject, payload)),
+                create_cohort,
                 ("cohorts", "write"),
                 False,
             ),
@@ -151,9 +169,7 @@ class CodexPlugin:
                 "permutive_update_cohort",
                 "Update a Permutive cohort from a JSON payload.",
                 self._object_schema(required=("resource_id", "payload")),
-                lambda resource_id, payload: client.cohorts.update(
-                    resource_id, cast(JSONObject, payload)
-                ),
+                update_cohort,
                 ("cohorts", "write"),
                 False,
             ),

--- a/src/PermutiveAPI/plugins/codex.py
+++ b/src/PermutiveAPI/plugins/codex.py
@@ -7,7 +7,11 @@ from typing import Any, Mapping, cast
 
 from ..agent import PermutiveAgentKit
 from ..client import PermutiveClient
-from ..credentials import CredentialsError, CredentialsProvider, LocalCredentialsProvider
+from ..credentials import (
+    CredentialsError,
+    CredentialsProvider,
+    LocalCredentialsProvider,
+)
 from ..mcp import PermutiveMCPConfig
 from ..sdk import JSONObject
 from ..tools import ToolDefinition, ToolRegistry

--- a/tests/test_codex_plugin_surface.py
+++ b/tests/test_codex_plugin_surface.py
@@ -63,9 +63,7 @@ def test_codex_plugin_supports_allow_list() -> None:
         ),
     )
 
-    assert [tool.name for tool in plugin.tools().list()] == [
-        "permutive_get_cohort"
-    ]
+    assert [tool.name for tool in plugin.tools().list()] == ["permutive_get_cohort"]
 
 
 def test_codex_plugin_validation_and_metadata_are_explicit() -> None:


### PR DESCRIPTION
## Summary
- format the local credential CLI and Codex plugin surface
- replace untyped Codex tool lambdas with typed handlers
- preserve tool names, schemas, behavior, and safety policy

## Validation
- AI-native platform evidence gate: pass
- Black: pass
- pydocstyle: pass
- Pyright: pass
- Python 3.9–3.13 test matrix: pass
- package build and clean installation: pass

No public API or runtime behavior change.