### PR TITLE
Execute the 6.5.1 product-validation and release-truth gates

### DIFF
--- a/.github/workflows/ai-native-platform.yml
+++ b/.github/workflows/ai-native-platform.yml
@@ -16,6 +16,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: python -m pip install PyYAML
+          cache: pip
+      - name: Install validation dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e . PyYAML
       - name: Validate declarations and repository evidence
         run: python scripts/validate_ai_native_platform.py
+      - name: Validate installed product surface
+        run: permutiveapi validate
+      - name: Validate release metadata
+        run: python scripts/validate_release_metadata.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e '.[dev]'
+      - name: Release metadata
+        run: python scripts/validate_release_metadata.py
       - name: Format
         run: black --check src tests
       - name: Docstrings
@@ -33,7 +35,7 @@ jobs:
       - name: Types
         run: pyright
       - name: Compile examples
-        run: python -m compileall -q src tests
+        run: python -m compileall -q src tests scripts
 
   tests:
     runs-on: ubuntu-latest
@@ -63,10 +65,28 @@ jobs:
           python-version: "3.12"
           cache: pip
       - run: python -m pip install --upgrade build twine
+      - run: python scripts/validate_release_metadata.py
       - run: python -m build
       - run: python -m twine check dist/*
-      - name: Verify clean install
+      - name: Verify core, CLI, and Python plugin install
+        shell: bash
         run: |
-          python -m venv /tmp/permutiveapi-venv
-          /tmp/permutiveapi-venv/bin/pip install dist/*.whl
-          /tmp/permutiveapi-venv/bin/python -c "import PermutiveAPI; print(PermutiveAPI.__all__)"
+          wheel="$(ls dist/*.whl)"
+          python -m venv /tmp/permutiveapi-core
+          /tmp/permutiveapi-core/bin/pip install "$wheel"
+          /tmp/permutiveapi-core/bin/python -c "import PermutiveAPI; print(PermutiveAPI.__all__)"
+          /tmp/permutiveapi-core/bin/permutiveapi validate
+      - name: Verify async extra install
+        shell: bash
+        run: |
+          wheel="$(ls dist/*.whl)"
+          python -m venv /tmp/permutiveapi-async
+          /tmp/permutiveapi-async/bin/pip install "${wheel}[async]"
+          /tmp/permutiveapi-async/bin/python -c "import httpx; from PermutiveAPI import AsyncPermutiveClient"
+      - name: Verify dataframe extra install
+        shell: bash
+        run: |
+          wheel="$(ls dist/*.whl)"
+          python -m venv /tmp/permutiveapi-dataframe
+          /tmp/permutiveapi-dataframe/bin/pip install "${wheel}[dataframe]"
+          /tmp/permutiveapi-dataframe/bin/python -c "import pandas; import PermutiveAPI"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - main
     paths:
       - pyproject.toml
+      - CHANGELOG.md
+      - docs/releases/**
+      - scripts/validate_release_metadata.py
       - .github/workflows/release.yml
   workflow_dispatch:
 
@@ -30,6 +33,9 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
+
+      - name: Validate release metadata
+        run: python scripts/validate_release_metadata.py
 
       - name: Resolve release version
         id: version

--- a/AI_NATIVE_PLATFORM.yaml
+++ b/AI_NATIVE_PLATFORM.yaml
@@ -38,7 +38,7 @@ plugin:
       require_local_env: true
 
 commands:
-  required: [configure, doctor, validate]
+  required: [configure, doctor, validate, test, docs, examples, upgrade, uninstall]
   recommended: [eval, benchmark]
 
 interfaces:

--- a/AI_NATIVE_PLATFORM.yaml
+++ b/AI_NATIVE_PLATFORM.yaml
@@ -38,7 +38,7 @@ plugin:
       require_local_env: true
 
 commands:
-  required: [configure, doctor, validate, test, docs, examples, upgrade, uninstall]
+  required: [configure, doctor, validate]
   recommended: [eval, benchmark]
 
 interfaces:
@@ -56,8 +56,8 @@ quality:
   examples: true
   security_scan: true
   compatibility_tests: true
-  ai_evaluations: true
-  benchmark: true
+  ai_evaluations: false
+  benchmark: false
 
 self_improvement:
   enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to PermutiveAPI are documented here. The project follows Semantic Versioning.
 
+## Unreleased
+
+### Changed
+- Published the active 6.5.1–6.7 roadmap with explicit product rules and non-goals.
+- Started reconciling package metadata, release documentation, CLI behavior, and AI-native evidence.
+
+## 6.5.0 - 2026-08-05
+
+### Added
+- First-class Codex plugin surface with deterministic discovery and explicit read-only or read-write policy.
+- Native Codex marketplace packaging and installation metadata.
+- Local-only `permutiveapi configure` and `permutiveapi doctor` credential workflows.
+- Governed tool execution with allow and deny policies and explicit approvals for mutating tools.
+- Structured invocation results and normalized failures.
+- Deterministic idempotency support for safe retries.
+- Bounded multi-step workflow execution and audit-sink integration.
+- Machine-readable AI-native platform manifest and dedicated CI validation.
+- Issue-driven self-improvement workflow with governed autonomous discovery and PR preparation.
+- Unified AgentKit access across local tools, workflows, and hosted MCP configuration.
+
+### Security
+- Credentials remain local, are never echoed, and must be ignored by Git.
+- Mutating tools require the declared write mode and explicit confirmation.
+- Breaking, security, credential, public API, permission, and release changes require human approval.
+
+### Changed
+- Repositioned the package as a typed, governed AI-native Python platform while preserving the canonical SDK.
+- Adopted the canonical AI-native platform standard at verified revision `67ec7caf19ead3282ea1aad29c43906f59e64d67`.
+
 ## 6.4.1 - 2026-08-05
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,13 +1,59 @@
 # Roadmap
 
-The roadmap is managed through GitHub issues and milestones.
+PermutiveAPI is moving from a completed first-class SDK and AI-native foundation to a verifiably trustworthy operating platform.
 
-Priorities are:
+## Product objective
 
-1. Complete and consistent API coverage
-2. Strong typing and validation
-3. Reliable error handling
-4. Clear documentation and examples
-5. Stable releases with minimal breaking changes
+Make PermutiveAPI the most trustworthy and easiest way for Python developers and governed AI agents to operate Permutive safely.
 
-The roadmap is directional, not a promise. Every item must support the product vision.
+## Now — 6.5.1: product truth
+
+Tracking issue: #185
+
+- Align package, changelog, tag, and release metadata.
+- Require automated evidence for every declared AI-native capability.
+- Reconcile declared lifecycle commands with the actual CLI.
+- Add one local `permutiveapi validate` product-health command.
+- Expand strict typing and clean-install validation across supported surfaces.
+- Keep the release backward compatible and dependency-light.
+
+## Next — 6.6: platform proof
+
+Tracking issue: #186
+
+- Add deterministic agent and policy evaluations.
+- Add a local mock Permutive server and end-to-end workflow tests.
+- Publish machine-readable evaluation results.
+- Version tool, plugin, and MCP capability negotiation.
+- Improve actionable errors and executable examples.
+
+## Then — 6.7: operational reliability
+
+Tracking issue: #187
+
+- Detect upstream request and response schema drift.
+- Add sanitized HTTP recording and deterministic replay.
+- Coordinate rate limits across sync and async concurrency.
+- Add credential rotation, stress tests, and performance budgets.
+- Validate release candidates from immutable publishable artifacts.
+
+## Non-goals until demonstrated demand
+
+- Plugin UI or dashboard.
+- Additional agent-framework adapters.
+- Third-party plugin marketplace.
+- Webhook or bulk-workflow frameworks.
+- Response caching or circuit breakers.
+- OpenTelemetry and additional dataframe engines.
+
+## Product rules
+
+1. Maintain one canonical SDK and tool contract.
+2. Prefer explicit behavior over magic.
+3. Prioritize reliability and safety over feature breadth.
+4. Require tests, documentation, and machine-readable evidence for every capability.
+5. Keep credentials local and never echo, commit, or remotely store them.
+6. Keep mutations governed by the declared approval policy.
+7. Keep `main` releasable after every merge.
+
+The canonical roadmap index is issue #188.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ Make PermutiveAPI the most trustworthy and easiest way for Python developers and
 
 ## Now — 6.5.1: product truth
 
-Tracking issue: #185
+Tracking issues: #185 and #190
 
 - Align package, changelog, tag, and release metadata.
 - Require automated evidence for every declared AI-native capability.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,14 +8,15 @@ Make PermutiveAPI the most trustworthy and easiest way for Python developers and
 
 ## Now — 6.5.1: product truth
 
-Tracking issues: #185 and #190
+Tracking issue: #185
 
-- Align package, changelog, tag, and release metadata.
-- Require automated evidence for every declared AI-native capability.
-- Reconcile declared lifecycle commands with the actual CLI.
-- Add one local `permutiveapi validate` product-health command.
-- Expand strict typing and clean-install validation across supported surfaces.
-- Keep the release backward compatible and dependency-light.
+Execution:
+
+- #190 — Local product validation, lifecycle commands, release consistency, and clean-install gates.
+- #191 — Canonical SDK, CLI, credential, and optional-extra onboarding documentation.
+- #192 — Complete supported-surface strict typing and artifact contracts.
+
+Release 6.5.1 follows only after all three execution issues pass their quality gates.
 
 ## Next — 6.6: platform proof
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,47 @@
+# PermutiveAPI CLI
+
+The `permutiveapi` command provides a small, deterministic lifecycle surface. It never uploads credentials and does not mutate the active Python environment without an explicit external package-manager command.
+
+## Credential commands
+
+### `permutiveapi configure`
+
+Interactively writes `PERMUTIVE_API_KEY` and `PERMUTIVE_WORKSPACE_ID` to a local `.env` file. Secret input is not echoed. Existing files are protected unless `--force` is supplied.
+
+### `permutiveapi doctor`
+
+Checks that the local credential file exists, contains the required variables, has restrictive permissions where supported, and is ignored by Git. Credential values are never displayed.
+
+## Product commands
+
+### `permutiveapi validate`
+
+Runs installed-package checks for distribution metadata, deterministic Python plugin discovery, and the public tool-registry contract. It is network-free and does not require credentials.
+
+### `permutiveapi test`
+
+Runs the deterministic installed-package self-test. Repository contributors should continue to use `pytest` for the complete source test suite.
+
+### `permutiveapi docs`
+
+Prints the canonical repository documentation locations.
+
+### `permutiveapi examples`
+
+Prints minimal canonical SDK and Codex plugin examples.
+
+## Environment lifecycle guidance
+
+### `permutiveapi upgrade`
+
+Prints the exact interpreter-specific `pip install --upgrade PermutiveAPI` command. It does not modify the environment automatically.
+
+### `permutiveapi uninstall`
+
+Prints the exact interpreter-specific `pip uninstall PermutiveAPI` command. It does not remove the package automatically.
+
+## Exit codes
+
+- `0`: the command completed successfully.
+- `1`: validation failed or local configuration needs repair.
+- `2`: required input is missing or an unsafe overwrite was refused.

--- a/docs/releases/6.5.0.md
+++ b/docs/releases/6.5.0.md
@@ -1,0 +1,36 @@
+# PermutiveAPI 6.5.0
+
+Released: 2026-08-05
+
+## Summary
+
+PermutiveAPI 6.5.0 is the first governed AI-native platform release. It preserves the typed synchronous and asynchronous SDK while adding a production-grade Codex plugin, local-only credential setup, governed tool execution, bounded workflows, structured results, deterministic idempotency, audit hooks, and machine-readable platform guarantees.
+
+## Highlights
+
+- First-class Codex marketplace plugin and Python plugin entry point.
+- Local-only `configure` and `doctor` credential commands.
+- Read-only defaults and explicit approval for mutating tools.
+- Policy-controlled tool execution with allow and deny rules.
+- Structured success and failure results.
+- Bounded multi-step workflows with deterministic idempotency.
+- Audit-sink support without credential or payload leakage.
+- Canonical AI-native manifest and dedicated CI evidence gate.
+- Issue-driven, governed self-improvement workflow.
+
+## Compatibility
+
+- Python 3.9–3.13 remain supported.
+- Existing synchronous, asynchronous, resource, query, configuration, and diagnostics APIs remain backward compatible.
+- The core installation remains independent of optional async and dataframe dependencies.
+
+## Security guarantees
+
+- Credentials remain local and are never echoed or remotely stored.
+- Local `.env` files require Git ignore coverage and restrictive permissions where supported.
+- Mutations require the declared write mode and explicit confirmation.
+- Breaking, security, credential, public API, permission, and release changes require human approval.
+
+## Validation
+
+The release is gated by Python CI and the AI-native platform validation workflow. Package build, type checking, deterministic tests, clean installation, plugin contracts, and platform evidence must pass before publication.

--- a/docs/roadmaps/README.md
+++ b/docs/roadmaps/README.md
@@ -1,0 +1,9 @@
+# Roadmap execution
+
+The active roadmap is maintained in `ROADMAP.md` and GitHub issue #188.
+
+- 6.5.1 product truth: #185 and #190
+- 6.6 deterministic platform proof: #186
+- 6.7 operational reliability: #187
+
+Every roadmap item must preserve the canonical SDK, remain backward compatible unless explicitly approved, and include tests, documentation, and machine-readable evidence.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,9 @@ include = [
     "docs",
     "README.md",
     "CHANGELOG.md",
+    "ROADMAP.md",
+    "PRODUCT.md",
+    "AI_NATIVE_PLATFORM.yaml",
     "PUBLIC_API.md",
     "API_COVERAGE.md",
     "MIGRATION.md",
@@ -95,6 +98,7 @@ include = [
     "src/PermutiveAPI/resources.py",
     "src/PermutiveAPI/sdk.py",
     "src/PermutiveAPI/tools.py",
+    "src/PermutiveAPI/validation.py",
 ]
 extraPaths = ["src"]
 typeCheckingMode = "strict"

--- a/scripts/validate_ai_native_platform.py
+++ b/scripts/validate_ai_native_platform.py
@@ -12,27 +12,60 @@ ROOT = Path(".")
 MANIFEST = ROOT / "AI_NATIVE_PLATFORM.yaml"
 STANDARD_REPOSITORY = "fatmambot33/ai-native-platform"
 REQUIRED_TRUE_PATHS = (
-    ("product", "ai_native"), ("product", "plugin_first"), ("product", "sdk_first"),
-    ("plugin", "enabled"), ("plugin", "codex", "supported"),
-    ("plugin", "codex", "marketplace"), ("plugin", "discovery", "entry_points"),
-    ("plugin", "discovery", "manifest"), ("plugin", "discovery", "capabilities"),
+    ("product", "ai_native"),
+    ("product", "plugin_first"),
+    ("product", "sdk_first"),
+    ("plugin", "enabled"),
+    ("plugin", "codex", "supported"),
+    ("plugin", "codex", "marketplace"),
+    ("plugin", "discovery", "entry_points"),
+    ("plugin", "discovery", "manifest"),
+    ("plugin", "discovery", "capabilities"),
     ("plugin", "credentials", "local_only"),
     ("plugin", "credentials", "policy", "never_store_remote"),
     ("plugin", "credentials", "policy", "never_commit"),
     ("plugin", "credentials", "policy", "never_echo"),
-    ("interfaces", "sdk"), ("interfaces", "cli"), ("interfaces", "plugin"),
-    ("interfaces", "json_schema"), ("quality", "typed"), ("quality", "tests"),
-    ("quality", "docs"), ("quality", "examples"), ("quality", "security_scan"),
-    ("self_improvement", "enabled"), ("self_improvement", "github", "issues"),
+    ("interfaces", "sdk"),
+    ("interfaces", "cli"),
+    ("interfaces", "plugin"),
+    ("interfaces", "json_schema"),
+    ("quality", "typed"),
+    ("quality", "tests"),
+    ("quality", "docs"),
+    ("quality", "examples"),
+    ("quality", "security_scan"),
+    ("self_improvement", "enabled"),
+    ("self_improvement", "github", "issues"),
     ("self_improvement", "autonomous", "discover_improvements"),
     ("self_improvement", "autonomous", "create_issues"),
     ("self_improvement", "autonomous", "generate_pr"),
     ("self_improvement", "autonomous", "run_ci"),
-    ("release", "block_if_quality_fails"), ("release", "block_if_plugin_invalid"),
+    ("release", "block_if_quality_fails"),
+    ("release", "block_if_plugin_invalid"),
 )
-REQUIRED_COMMANDS = {"validate", "test", "docs", "examples", "upgrade", "uninstall"}
-REQUIRED_GUARANTEES = {"deterministic_tool_discovery", "structured_outputs", "issue_driven_improvement", "ci_validated_changes", "governed_autonomy"}
-REQUIRED_APPROVALS = {"breaking_changes", "security_changes", "credential_changes", "public_api_changes", "permission_expansion", "release_changes"}
+REQUIRED_COMMANDS = {
+    "validate",
+    "test",
+    "docs",
+    "examples",
+    "upgrade",
+    "uninstall",
+}
+REQUIRED_GUARANTEES = {
+    "deterministic_tool_discovery",
+    "structured_outputs",
+    "issue_driven_improvement",
+    "ci_validated_changes",
+    "governed_autonomy",
+}
+REQUIRED_APPROVALS = {
+    "breaking_changes",
+    "security_changes",
+    "credential_changes",
+    "public_api_changes",
+    "permission_expansion",
+    "release_changes",
+}
 
 
 def read_path(data: dict[str, Any], path: tuple[str, ...]) -> Any:
@@ -47,12 +80,29 @@ def read_path(data: dict[str, Any], path: tuple[str, ...]) -> Any:
 
 def matching(patterns: Iterable[str]) -> list[Path]:
     """Return matching repository files."""
-    return sorted({path for pattern in patterns for path in ROOT.glob(pattern) if path.is_file() and ".git" not in path.parts})
+    return sorted(
+        {
+            path
+            for pattern in patterns
+            for path in ROOT.glob(pattern)
+            if path.is_file() and ".git" not in path.parts
+        }
+    )
 
 
 def text(paths: Iterable[Path]) -> str:
     """Read small text files as lowercase text."""
-    return "\n".join(path.read_text(encoding="utf-8", errors="ignore") for path in paths if path.stat().st_size < 2_000_000).lower()
+    return "\n".join(
+        path.read_text(encoding="utf-8", errors="ignore")
+        for path in paths
+        if path.stat().st_size < 2_000_000
+    ).lower()
+
+
+def _command_is_implemented(cli_text: str, command: str) -> bool:
+    """Return whether one declared command appears in the CLI parser contract."""
+    quoted = (f'"{command}"', f"'{command}'")
+    return any(value in cli_text for value in quoted) and "add_parser" in cli_text
 
 
 def evidence(data: dict[str, Any]) -> list[str]:
@@ -64,43 +114,101 @@ def evidence(data: dict[str, Any]) -> list[str]:
     docs = text(readmes)
     code = text(source)
     ci = text(workflows)
+    pyproject = ROOT / "pyproject.toml"
+    cli_path = ROOT / "src/PermutiveAPI/cli.py"
+    cli_text = (
+        cli_path.read_text(encoding="utf-8", errors="ignore").lower()
+        if cli_path.is_file()
+        else ""
+    )
     checks = {
-        "pyproject.toml": (ROOT / "pyproject.toml").is_file(),
-        "Codex plugin manifest": bool(matching((".codex-plugin/plugin.json", "plugins/**/.codex-plugin/plugin.json"))),
-        "Codex marketplace catalog": bool(matching((".agents/plugins/marketplace.json", "plugins/**/marketplace.json"))),
-        "typed plugin contract": "plugin" in code and ("protocol" in code or "abstractbaseclass" in code),
-        "typing marker or explicit Pyright contract": bool(matching(("src/**/py.typed", "**/py.typed"))) or "pyright" in text([ROOT / "pyproject.toml"]),
+        "pyproject.toml": pyproject.is_file(),
+        "Codex plugin manifest": bool(
+            matching(
+                (
+                    ".codex-plugin/plugin.json",
+                    "plugins/**/.codex-plugin/plugin.json",
+                )
+            )
+        ),
+        "Codex marketplace catalog": bool(
+            matching((".agents/plugins/marketplace.json", "plugins/**/marketplace.json"))
+        ),
+        "typed plugin contract": "plugin" in code
+        and ("protocol" in code or "abstractbaseclass" in code),
+        "typing marker or explicit Pyright contract": bool(
+            matching(("src/**/py.typed", "**/py.typed"))
+        )
+        or "pyright" in text([pyproject]),
         "strict type checking in CI": "pyright" in ci or "mypy" in ci,
         "plugin tests": any("plugin" in path.name.lower() for path in tests),
         "general tests": bool(tests),
         "AGENTS.md": (ROOT / "AGENTS.md").is_file(),
         "PyPI installation documentation": "pip install" in docs,
-        "Git installation documentation": "git+https://" in docs or "git clone" in docs,
+        "Git installation documentation": "git+https://" in docs
+        or "git clone" in docs,
         "editable installation documentation": "pip install -e" in docs,
         "plugin documentation": "plugin" in docs and "codex" in docs,
-        "AI improvement issue template": (ROOT / ".github/ISSUE_TEMPLATE/ai-improvement.yml").is_file(),
-        "self-improvement workflow": (ROOT / ".github/workflows/ai-self-improvement.yml").is_file() or (ROOT / ".github/workflows/ai-self-improve.yml").is_file(),
+        "AI improvement issue template": (
+            ROOT / ".github/ISSUE_TEMPLATE/ai-improvement.yml"
+        ).is_file(),
+        "self-improvement workflow": (
+            ROOT / ".github/workflows/ai-self-improvement.yml"
+        ).is_file()
+        or (ROOT / ".github/workflows/ai-self-improve.yml").is_file(),
     }
+    declared_commands = set(data.get("commands", {}).get("required", []))
+    for command in sorted(declared_commands):
+        checks[f"implemented CLI command: {command}"] = _command_is_implemented(
+            cli_text,
+            command,
+        )
+
+    quality = data.get("quality", {})
+    if quality.get("ai_evaluations") is True:
+        checks["AI evaluation harness"] = bool(
+            matching(("evals/**/*.py", "tests/**/*eval*.py", "tests/test_eval*.py"))
+        )
+    if quality.get("benchmark") is True:
+        checks["benchmark suite"] = bool(
+            matching(("benchmarks/**/*.py", "tests/**/*benchmark*.py"))
+        ) or "pytest-benchmark" in text([pyproject])
+
     credentials = data.get("plugin", {}).get("credentials", {})
     if credentials.get("required"):
-        checks["credential template"] = isinstance(credentials.get("env_example"), str) and (ROOT / credentials["env_example"]).is_file()
+        env_example = credentials.get("env_example")
+        checks["credential template"] = isinstance(env_example, str) and (
+            ROOT / env_example
+        ).is_file()
         checks["configure command"] = bool(credentials.get("setup_command"))
         checks["doctor command"] = bool(credentials.get("validation_command"))
-        checks[".env ignored"] = (ROOT / ".gitignore").is_file() and ".env" in (ROOT / ".gitignore").read_text(encoding="utf-8", errors="ignore")
+        checks[".env ignored"] = (ROOT / ".gitignore").is_file() and ".env" in (
+            ROOT / ".gitignore"
+        ).read_text(encoding="utf-8", errors="ignore")
     return [label for label, passed in checks.items() if not passed]
 
 
 def main() -> int:
     """Validate the local manifest and repository evidence."""
-    data = yaml.safe_load(MANIFEST.read_text(encoding="utf-8")) if MANIFEST.is_file() else None
+    data = (
+        yaml.safe_load(MANIFEST.read_text(encoding="utf-8"))
+        if MANIFEST.is_file()
+        else None
+    )
     if not isinstance(data, dict) or data.get("version") != 1:
-        print("AI-native platform validation failed:\n- missing or invalid version 1 manifest")
+        print(
+            "AI-native platform validation failed:\n"
+            "- missing or invalid version 1 manifest"
+        )
         return 1
     errors: list[str] = []
     standard = data.get("standard", {})
     if standard.get("repository") != STANDARD_REPOSITORY:
         errors.append(f"standard.repository must be {STANDARD_REPOSITORY}")
-    if not re.fullmatch(r"[0-9a-f]{40}|v?\d+\.\d+\.\d+", str(standard.get("ref", ""))):
+    if not re.fullmatch(
+        r"[0-9a-f]{40}|v?\d+\.\d+\.\d+",
+        str(standard.get("ref", "")),
+    ):
         errors.append("standard.ref must pin an immutable commit or semantic version")
     for path in REQUIRED_TRUE_PATHS:
         try:
@@ -109,19 +217,47 @@ def main() -> int:
         except KeyError:
             errors.append(f"missing {'.'.join(path)}")
     commands = set(data.get("commands", {}).get("required", []))
-    errors.extend(f"commands.required must include {item}" for item in sorted(REQUIRED_COMMANDS - commands))
+    errors.extend(
+        f"commands.required must include {item}"
+        for item in sorted(REQUIRED_COMMANDS - commands)
+    )
     credentials = data.get("plugin", {}).get("credentials", {})
     if credentials.get("required"):
-        errors.extend(f"plugin.credentials.{field} is required" for field in ("env_file", "env_example", "setup_command", "validation_command") if not credentials.get(field))
-        errors.extend(f"credentialed products require command {item}" for item in ("configure", "doctor") if item not in commands)
-    approvals = data.get("self_improvement", {}).get("governance", {}).get("human_approval", {})
-    missing_approvals = sorted(name for name in REQUIRED_APPROVALS if approvals.get(name) is not True)
+        errors.extend(
+            f"plugin.credentials.{field} is required"
+            for field in (
+                "env_file",
+                "env_example",
+                "setup_command",
+                "validation_command",
+            )
+            if not credentials.get(field)
+        )
+        errors.extend(
+            f"credentialed products require command {item}"
+            for item in ("configure", "doctor")
+            if item not in commands
+        )
+    approvals = (
+        data.get("self_improvement", {})
+        .get("governance", {})
+        .get("human_approval", {})
+    )
+    missing_approvals = sorted(
+        name for name in REQUIRED_APPROVALS if approvals.get(name) is not True
+    )
     if missing_approvals:
         errors.append("missing human approval gates: " + ", ".join(missing_approvals))
-    missing_guarantees = sorted(REQUIRED_GUARANTEES - set(data.get("agent", {}).get("guarantees", [])))
+    missing_guarantees = sorted(
+        REQUIRED_GUARANTEES - set(data.get("agent", {}).get("guarantees", []))
+    )
     if missing_guarantees:
-        errors.append("missing agent guarantees: " + ", ".join(missing_guarantees))
-    errors.extend(f"missing repository evidence: {label}" for label in evidence(data))
+        errors.append(
+            "missing agent guarantees: " + ", ".join(missing_guarantees)
+        )
+    errors.extend(
+        f"missing repository evidence: {label}" for label in evidence(data)
+    )
     if errors:
         print("AI-native platform validation failed:")
         for error in errors:

--- a/scripts/validate_release_metadata.py
+++ b/scripts/validate_release_metadata.py
@@ -1,0 +1,85 @@
+"""Validate local release metadata without network access."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+VERSION_PATTERN = re.compile(
+    r'^version\s*=\s*"(?P<version>[^\"]+)"\s*$',
+    re.MULTILINE,
+)
+CHANGELOG_PATTERN = r"^## {version} - \d{{4}}-\d{{2}}-\d{{2}}$"
+
+
+def project_version(pyproject: Path) -> str:
+    """Read the project version from pyproject.toml."""
+    text = pyproject.read_text(encoding="utf-8")
+    project_start = text.find("[project]")
+    if project_start < 0:
+        raise ValueError("pyproject.toml has no [project] table")
+    next_table = text.find("\n[", project_start + len("[project]"))
+    project_text = text[project_start : next_table if next_table >= 0 else None]
+    match = VERSION_PATTERN.search(project_text)
+    if match is None:
+        raise ValueError("pyproject.toml [project] table has no version")
+    return match.group("version")
+
+
+def validate(root: Path, expected_tag: str | None = None) -> list[str]:
+    """Return release metadata consistency errors."""
+    errors: list[str] = []
+    pyproject = root / "pyproject.toml"
+    changelog = root / "CHANGELOG.md"
+    if not pyproject.is_file():
+        return ["missing pyproject.toml"]
+    if not changelog.is_file():
+        return ["missing CHANGELOG.md"]
+    try:
+        version = project_version(pyproject)
+    except ValueError as error:
+        return [str(error)]
+
+    changelog_text = changelog.read_text(encoding="utf-8")
+    heading = re.compile(
+        CHANGELOG_PATTERN.format(version=re.escape(version)),
+        re.MULTILINE,
+    )
+    if heading.search(changelog_text) is None:
+        errors.append(
+            f"CHANGELOG.md must contain a dated `## {version} - YYYY-MM-DD` heading"
+        )
+
+    release_notes = root / "docs" / "releases" / f"{version}.md"
+    if not release_notes.is_file():
+        errors.append(f"missing release notes: {release_notes.as_posix()}")
+
+    if expected_tag is not None:
+        normalized_tag = expected_tag.removeprefix("refs/tags/").removeprefix("v")
+        if normalized_tag != version:
+            errors.append(
+                f"tag version {normalized_tag!r} does not match project version {version!r}"
+            )
+    return errors
+
+
+def main() -> int:
+    """Run release metadata validation."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path("."))
+    parser.add_argument("--tag")
+    args = parser.parse_args()
+    errors = validate(args.root, args.tag)
+    if errors:
+        print("Release metadata validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    version = project_version(args.root / "pyproject.toml")
+    print(f"Release metadata validation passed for PermutiveAPI {version}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/PermutiveAPI/cli.py
+++ b/src/PermutiveAPI/cli.py
@@ -1,4 +1,4 @@
-"""Local-only credential setup commands for PermutiveAPI."""
+"""Local-only credential setup and validation commands for PermutiveAPI."""
 
 from __future__ import annotations
 
@@ -9,6 +9,8 @@ from pathlib import Path
 from typing import Dict, Optional, Sequence
 
 from dotenv import dotenv_values
+
+from .validation import run_validation, validation_succeeded
 
 REQUIRED_VARIABLES = ("PERMUTIVE_API_KEY", "PERMUTIVE_WORKSPACE_ID")
 
@@ -96,6 +98,20 @@ def doctor(env_file: Path) -> int:
     return 0
 
 
+def validate() -> int:
+    """Validate the installed product surface without requiring credentials."""
+    results = run_validation()
+    print("PermutiveAPI product validation")
+    for result in results:
+        status = "PASS" if result.passed else "FAIL"
+        print(f"- [{status}] {result.name}: {result.detail}")
+    if validation_succeeded(results):
+        print("PermutiveAPI product validation passed.")
+        return 0
+    print("PermutiveAPI product validation failed.")
+    return 1
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the command-line parser."""
     parser = argparse.ArgumentParser(prog="permutiveapi")
@@ -105,6 +121,7 @@ def build_parser() -> argparse.ArgumentParser:
     configure_parser.add_argument("--force", action="store_true")
     doctor_parser = subparsers.add_parser("doctor")
     doctor_parser.add_argument("--env-file", type=Path, default=Path(".env"))
+    subparsers.add_parser("validate")
     return parser
 
 
@@ -113,7 +130,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     args = build_parser().parse_args(argv)
     if args.command == "configure":
         return configure(args.env_file, force=args.force)
-    return doctor(args.env_file)
+    if args.command == "doctor":
+        return doctor(args.env_file)
+    return validate()
 
 
 if __name__ == "__main__":

--- a/src/PermutiveAPI/cli.py
+++ b/src/PermutiveAPI/cli.py
@@ -16,9 +16,18 @@ from .validation import run_validation, validation_succeeded
 REQUIRED_VARIABLES = ("PERMUTIVE_API_KEY", "PERMUTIVE_WORKSPACE_ID")
 DOCUMENTATION_PATHS = (
     "README.md",
+    "docs/CLI.md",
     "docs/AI_NATIVE.md",
     "docs/AI_NATIVE_PLUGIN.md",
     "docs/MCP.md",
+)
+LIFECYCLE_COMMANDS = (
+    "validate",
+    "test",
+    "docs",
+    "examples",
+    "upgrade",
+    "uninstall",
 )
 
 
@@ -171,7 +180,7 @@ def build_parser() -> argparse.ArgumentParser:
     configure_parser.add_argument("--force", action="store_true")
     doctor_parser = subparsers.add_parser("doctor")
     doctor_parser.add_argument("--env-file", type=Path, default=Path(".env"))
-    for command in ("validate", "test", "docs", "examples", "upgrade", "uninstall"):
+    for command in LIFECYCLE_COMMANDS:
         subparsers.add_parser(command)
     return parser
 

--- a/src/PermutiveAPI/cli.py
+++ b/src/PermutiveAPI/cli.py
@@ -1,10 +1,11 @@
-"""Local-only credential setup and validation commands for PermutiveAPI."""
+"""Local credential, validation, and lifecycle commands for PermutiveAPI."""
 
 from __future__ import annotations
 
 import argparse
 import getpass
 import os
+import sys
 from pathlib import Path
 from typing import Dict, Optional, Sequence
 
@@ -13,6 +14,12 @@ from dotenv import dotenv_values
 from .validation import run_validation, validation_succeeded
 
 REQUIRED_VARIABLES = ("PERMUTIVE_API_KEY", "PERMUTIVE_WORKSPACE_ID")
+DOCUMENTATION_PATHS = (
+    "README.md",
+    "docs/AI_NATIVE.md",
+    "docs/AI_NATIVE_PLUGIN.md",
+    "docs/MCP.md",
+)
 
 
 def _is_ignored(env_path: Path) -> bool:
@@ -112,6 +119,49 @@ def validate() -> int:
     return 1
 
 
+def test() -> int:
+    """Run the deterministic installed-package self-test."""
+    print("PermutiveAPI installed-package self-test")
+    return validate()
+
+
+def docs() -> int:
+    """Print the canonical documentation locations."""
+    print("PermutiveAPI documentation")
+    for path in DOCUMENTATION_PATHS:
+        print(f"- {path}")
+    print("Repository: https://github.com/fatmambot33/PermutiveAPI")
+    return 0
+
+
+def examples() -> int:
+    """Print minimal canonical SDK and plugin examples."""
+    print("PermutiveAPI SDK example")
+    print("from PermutiveAPI import PermutiveClient")
+    print('client = PermutiveClient("api-key")')
+    print('cohort = client.cohorts.get("cohort-id")')
+    print()
+    print("PermutiveAPI Codex plugin example")
+    print("from PermutiveAPI.plugins.codex import CodexPlugin")
+    print("plugin = CodexPlugin.from_env()")
+    print("tools = plugin.tools().as_openai_tools()")
+    return 0
+
+
+def upgrade() -> int:
+    """Print the explicit environment-safe package upgrade command."""
+    print("Upgrade PermutiveAPI explicitly with:")
+    print(f"{sys.executable} -m pip install --upgrade PermutiveAPI")
+    return 0
+
+
+def uninstall() -> int:
+    """Print the explicit environment-safe package removal command."""
+    print("Uninstall PermutiveAPI explicitly with:")
+    print(f"{sys.executable} -m pip uninstall PermutiveAPI")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the command-line parser."""
     parser = argparse.ArgumentParser(prog="permutiveapi")
@@ -121,7 +171,8 @@ def build_parser() -> argparse.ArgumentParser:
     configure_parser.add_argument("--force", action="store_true")
     doctor_parser = subparsers.add_parser("doctor")
     doctor_parser.add_argument("--env-file", type=Path, default=Path(".env"))
-    subparsers.add_parser("validate")
+    for command in ("validate", "test", "docs", "examples", "upgrade", "uninstall"):
+        subparsers.add_parser(command)
     return parser
 
 
@@ -132,7 +183,15 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return configure(args.env_file, force=args.force)
     if args.command == "doctor":
         return doctor(args.env_file)
-    return validate()
+    commands = {
+        "validate": validate,
+        "test": test,
+        "docs": docs,
+        "examples": examples,
+        "upgrade": upgrade,
+        "uninstall": uninstall,
+    }
+    return commands[args.command]()
 
 
 if __name__ == "__main__":

--- a/src/PermutiveAPI/validation.py
+++ b/src/PermutiveAPI/validation.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from importlib import metadata
-from typing import Callable, List, Sequence
+from typing import Callable, List, Optional, Sequence
 
 
 @dataclass(frozen=True)
@@ -13,11 +13,11 @@ class ValidationCheck:
 
     Parameters
     ----------
-    name:
+    name
         Stable machine-readable check name.
-    passed:
+    passed
         Whether the check passed.
-    detail:
+    detail
         Human-readable result without credential or payload values.
     """
 
@@ -54,16 +54,12 @@ def _package_metadata_check() -> ValidationCheck:
 
 def _plugin_entry_point_check() -> ValidationCheck:
     """Validate the built-in Python plugin entry point."""
-    entry_points = metadata.entry_points()
-    if hasattr(entry_points, "select"):
-        candidates = entry_points.select(group="permutiveapi.plugins", name="codex")
-    else:  # pragma: no cover - compatibility for older importlib metadata APIs
-        candidates = [
-            entry_point
-            for entry_point in entry_points.get("permutiveapi.plugins", [])
-            if entry_point.name == "codex"
-        ]
-    matches = list(candidates)
+    matches = list(
+        metadata.entry_points().select(
+            group="permutiveapi.plugins",
+            name="codex",
+        )
+    )
     if len(matches) != 1:
         return ValidationCheck(
             name="plugin_entry_point",
@@ -92,7 +88,7 @@ def _plugin_entry_point_check() -> ValidationCheck:
 
 
 def _public_tools_check() -> ValidationCheck:
-    """Validate that public OpenAI tool schemas are available."""
+    """Validate that the public tool registry surface is available."""
     try:
         from PermutiveAPI.tools import ToolRegistry
     except ImportError as error:
@@ -118,13 +114,13 @@ def _public_tools_check() -> ValidationCheck:
 
 
 def run_validation(
-    checks: Sequence[CheckRunner] | None = None,
+    checks: Optional[Sequence[CheckRunner]] = None,
 ) -> List[ValidationCheck]:
     """Run deterministic local product validation.
 
     Parameters
     ----------
-    checks:
+    checks
         Optional check runners for deterministic testing.
 
     Returns

--- a/src/PermutiveAPI/validation.py
+++ b/src/PermutiveAPI/validation.py
@@ -1,0 +1,145 @@
+"""Local product validation for the installed PermutiveAPI package."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import metadata
+from typing import Callable, List, Sequence
+
+
+@dataclass(frozen=True)
+class ValidationCheck:
+    """Represent one deterministic, secret-free validation check.
+
+    Parameters
+    ----------
+    name:
+        Stable machine-readable check name.
+    passed:
+        Whether the check passed.
+    detail:
+        Human-readable result without credential or payload values.
+    """
+
+    name: str
+    passed: bool
+    detail: str
+
+
+CheckRunner = Callable[[], ValidationCheck]
+
+
+def _package_metadata_check() -> ValidationCheck:
+    """Validate installed package metadata."""
+    try:
+        version = metadata.version("PermutiveAPI")
+    except metadata.PackageNotFoundError:
+        return ValidationCheck(
+            name="package_metadata",
+            passed=False,
+            detail="PermutiveAPI distribution metadata is unavailable.",
+        )
+    if not version:
+        return ValidationCheck(
+            name="package_metadata",
+            passed=False,
+            detail="PermutiveAPI version metadata is empty.",
+        )
+    return ValidationCheck(
+        name="package_metadata",
+        passed=True,
+        detail=f"PermutiveAPI {version} metadata is available.",
+    )
+
+
+def _plugin_entry_point_check() -> ValidationCheck:
+    """Validate the built-in Python plugin entry point."""
+    entry_points = metadata.entry_points()
+    if hasattr(entry_points, "select"):
+        candidates = entry_points.select(group="permutiveapi.plugins", name="codex")
+    else:  # pragma: no cover - compatibility for older importlib metadata APIs
+        candidates = [
+            entry_point
+            for entry_point in entry_points.get("permutiveapi.plugins", [])
+            if entry_point.name == "codex"
+        ]
+    matches = list(candidates)
+    if len(matches) != 1:
+        return ValidationCheck(
+            name="plugin_entry_point",
+            passed=False,
+            detail="Expected exactly one permutiveapi.plugins codex entry point.",
+        )
+    try:
+        plugin_type = matches[0].load()
+    except (ImportError, AttributeError, ModuleNotFoundError) as error:
+        return ValidationCheck(
+            name="plugin_entry_point",
+            passed=False,
+            detail=f"Codex plugin entry point could not load: {type(error).__name__}.",
+        )
+    if plugin_type.__name__ != "CodexPlugin":
+        return ValidationCheck(
+            name="plugin_entry_point",
+            passed=False,
+            detail="Codex plugin entry point resolved to an unexpected type.",
+        )
+    return ValidationCheck(
+        name="plugin_entry_point",
+        passed=True,
+        detail="Codex plugin entry point resolves deterministically.",
+    )
+
+
+def _public_tools_check() -> ValidationCheck:
+    """Validate that public OpenAI tool schemas are available."""
+    try:
+        from PermutiveAPI.tools import ToolRegistry
+    except ImportError as error:
+        return ValidationCheck(
+            name="public_tools",
+            passed=False,
+            detail=f"Tool registry import failed: {type(error).__name__}.",
+        )
+    required_methods = ("as_openai_tools", "capabilities")
+    missing = [name for name in required_methods if not hasattr(ToolRegistry, name)]
+    if missing:
+        return ValidationCheck(
+            name="public_tools",
+            passed=False,
+            detail="Tool registry is missing required public methods: "
+            + ", ".join(missing),
+        )
+    return ValidationCheck(
+        name="public_tools",
+        passed=True,
+        detail="Public tool schema and capability methods are available.",
+    )
+
+
+def run_validation(
+    checks: Sequence[CheckRunner] | None = None,
+) -> List[ValidationCheck]:
+    """Run deterministic local product validation.
+
+    Parameters
+    ----------
+    checks:
+        Optional check runners for deterministic testing.
+
+    Returns
+    -------
+    list of ValidationCheck
+        Ordered validation results.
+    """
+    runners = checks or (
+        _package_metadata_check,
+        _plugin_entry_point_check,
+        _public_tools_check,
+    )
+    return [runner() for runner in runners]
+
+
+def validation_succeeded(results: Sequence[ValidationCheck]) -> bool:
+    """Return whether every validation check passed."""
+    return bool(results) and all(result.passed for result in results)

--- a/src/PermutiveAPI/validation.py
+++ b/src/PermutiveAPI/validation.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from importlib import metadata
-from typing import Callable, List, Optional, Sequence
+from typing import Any, Callable, List, Optional, Sequence
 
 
 @dataclass(frozen=True)
@@ -54,12 +54,20 @@ def _package_metadata_check() -> ValidationCheck:
 
 def _plugin_entry_point_check() -> ValidationCheck:
     """Validate the built-in Python plugin entry point."""
-    matches = list(
-        metadata.entry_points().select(
-            group="permutiveapi.plugins",
-            name="codex",
+    entry_points: Any = metadata.entry_points()
+    if hasattr(entry_points, "select"):
+        matches = list(
+            entry_points.select(
+                group="permutiveapi.plugins",
+                name="codex",
+            )
         )
-    )
+    else:  # pragma: no cover - Python 3.9 importlib.metadata compatibility
+        matches = [
+            entry_point
+            for entry_point in entry_points.get("permutiveapi.plugins", ())
+            if entry_point.name == "codex"
+        ]
     if len(matches) != 1:
         return ValidationCheck(
             name="plugin_entry_point",

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,57 @@
+"""Contract tests for local product validation."""
+
+from __future__ import annotations
+
+from typing import List
+
+from PermutiveAPI.cli import main
+from PermutiveAPI.validation import (
+    ValidationCheck,
+    run_validation,
+    validation_succeeded,
+)
+
+
+def test_run_validation_preserves_check_order() -> None:
+    """Validation results remain deterministic."""
+
+    def first() -> ValidationCheck:
+        return ValidationCheck("first", True, "first passed")
+
+    def second() -> ValidationCheck:
+        return ValidationCheck("second", False, "second failed")
+
+    results = run_validation((first, second))
+
+    assert [result.name for result in results] == ["first", "second"]
+    assert validation_succeeded(results) is False
+
+
+def test_validation_requires_at_least_one_check() -> None:
+    """An empty check set cannot report a false positive."""
+    results: List[ValidationCheck] = []
+
+    assert validation_succeeded(results) is False
+
+
+def test_validate_cli_reports_passes(monkeypatch, capsys) -> None:
+    """The validate command returns zero when every check passes."""
+    checks = [ValidationCheck("contract", True, "contract is valid")]
+    monkeypatch.setattr("PermutiveAPI.cli.run_validation", lambda: checks)
+
+    assert main(["validate"]) == 0
+    output = capsys.readouterr().out
+    assert "[PASS] contract" in output
+    assert "product validation passed" in output
+
+
+def test_validate_cli_reports_failures(monkeypatch, capsys) -> None:
+    """The validate command returns one with actionable failure output."""
+    checks = [ValidationCheck("contract", False, "contract is invalid")]
+    monkeypatch.setattr("PermutiveAPI.cli.run_validation", lambda: checks)
+
+    assert main(["validate"]) == 1
+    output = capsys.readouterr().out
+    assert "[FAIL] contract" in output
+    assert "contract is invalid" in output
+    assert "product validation failed" in output

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,8 +1,10 @@
-"""Contract tests for local product validation."""
+"""Contract tests for local product validation and lifecycle commands."""
 
 from __future__ import annotations
 
 from typing import List
+
+import pytest
 
 from PermutiveAPI.cli import main
 from PermutiveAPI.validation import (
@@ -55,3 +57,34 @@ def test_validate_cli_reports_failures(monkeypatch, capsys) -> None:
     assert "[FAIL] contract" in output
     assert "contract is invalid" in output
     assert "product validation failed" in output
+
+
+def test_test_command_runs_installed_package_checks(monkeypatch, capsys) -> None:
+    """The test command reuses deterministic installed-package validation."""
+    checks = [ValidationCheck("self_test", True, "self-test passed")]
+    monkeypatch.setattr("PermutiveAPI.cli.run_validation", lambda: checks)
+
+    assert main(["test"]) == 0
+    output = capsys.readouterr().out
+    assert "installed-package self-test" in output
+    assert "[PASS] self_test" in output
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    (
+        ("docs", "docs/AI_NATIVE.md"),
+        ("examples", "PermutiveClient"),
+        ("upgrade", "pip install --upgrade PermutiveAPI"),
+        ("uninstall", "pip uninstall PermutiveAPI"),
+    ),
+)
+def test_lifecycle_guidance_commands_are_deterministic(
+    command: str,
+    expected: str,
+    capsys,
+) -> None:
+    """Lifecycle commands return stable, explicit guidance."""
+    assert main([command]) == 0
+
+    assert expected in capsys.readouterr().out


### PR DESCRIPTION
Closes #190.
Advances #185 and #188.

## What changed

- publish the active 6.5.1–6.7 roadmap with explicit execution issues and non-goals
- add complete 6.5.0 changelog and release documentation
- implement the canonical `configure`, `doctor`, `validate`, `test`, `docs`, `examples`, `upgrade`, and `uninstall` CLI contract
- add deterministic, credential-free installed-product validation
- require implementation evidence for declared CLI commands and conditional evidence for evaluations and benchmarks
- add release metadata consistency validation for package version, changelog, release notes, and optional tags
- run release truth checks in pull-request, AI-native, package, and release workflows
- validate clean wheel installs for the core CLI and Python plugin, async extra, and dataframe extra
- include roadmap and AI-native contracts in source distributions
- document lifecycle command behavior and safety guarantees

## Product impact

This is backward-compatible maintenance. It removes machine-readable overclaims, makes every currently declared lifecycle command executable, and blocks release or artifact drift before publication.

## Validation

- AI-native platform gate: passed
- release metadata validation: passed
- Black: passed
- NumPy docstrings: passed
- strict Pyright: passed
- Python 3.9–3.13 tests and coverage: passed
- wheel and source distribution build: passed
- Twine validation: passed
- clean core, CLI, and Python plugin install: passed
- clean async extra install: passed
- clean dataframe extra install: passed
