### PR TITLE
Release PermutiveAPI 6.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,29 @@
 
 All notable changes to PermutiveAPI are documented here. The project follows Semantic Versioning.
 
-## Unreleased
+## 6.5.1 - 2026-08-06
+
+### Added
+- Deterministic `permutiveapi validate`, `test`, `docs`, `examples`, `upgrade`, and `uninstall` lifecycle commands.
+- Secret-free installed-product checks for package metadata, Python plugin discovery, and the public tool contract.
+- AI-native evidence validation for declared commands and conditional evaluation or benchmark claims.
+- Release metadata consistency checks for package version, changelog headings, release notes, and release tags.
+- Clean-install validation for the core SDK, CLI, Python plugin, async extra, and dataframe extra.
+- Versioned `TYPING_SCOPE.json` with strict and compatibility module classifications.
+- Downstream strict type-consumption examples and complete canonical wheel-content checks.
 
 ### Changed
 - Published the active 6.5.1–6.7 roadmap with explicit product rules and non-goals.
-- Added deterministic installed-product, AI-native evidence, release metadata, and clean-install validation gates.
 - Replaced legacy onboarding with one canonical guide for the sync SDK, async extra, dataframe extra, CLI, Codex plugin, and project contracts.
 - Simplified local credential setup to require only `PERMUTIVE_API_KEY`, the credential consumed by the SDK and plugin.
-- Explicitly labelled legacy resource classes as compatibility surfaces rather than the recommended entry point.
+- Reconciled `PUBLIC_API.md` with the complete 6.5 package-root surface.
+- Made strict Pyright coverage exactly match the declared canonical module group.
+- Explicitly bounded legacy compatibility exclusions so new modules cannot silently escape typing review.
+
+### Fixed
+- Removed an unused diagnostics type import exposed by complete strict analysis.
+- Corrected typed query examples to pass an iterable of expressions to `all_of`.
+- Prevented machine-readable platform declarations from claiming unevidenced evaluations or benchmarks.
 
 ## 6.5.0 - 2026-08-05
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,19 +6,17 @@ PermutiveAPI is moving from a completed first-class SDK and AI-native foundation
 
 Make PermutiveAPI the most trustworthy and easiest way for Python developers and governed AI agents to operate Permutive safely.
 
-## Now — 6.5.1: product truth
+## Completed — 6.5.1: product truth
 
 Tracking issue: #185
 
-Execution:
+- [x] #190 — Local product validation, lifecycle commands, release consistency, and clean-install gates.
+- [x] #191 — Canonical SDK, CLI, credential, and optional-extra onboarding documentation.
+- [x] #192 — Complete supported-surface strict typing and artifact contracts.
 
-- #190 — Local product validation, lifecycle commands, release consistency, and clean-install gates.
-- #191 — Canonical SDK, CLI, credential, and optional-extra onboarding documentation.
-- #192 — Complete supported-surface strict typing and artifact contracts.
+The 6.5.1 patch release establishes verifiable product claims, truthful onboarding, and an explicit canonical typing boundary.
 
-Release 6.5.1 follows only after all three execution issues pass their quality gates.
-
-## Next — 6.6: platform proof
+## Now — 6.6: platform proof
 
 Tracking issue: #186
 

--- a/docs/releases/6.5.1.md
+++ b/docs/releases/6.5.1.md
@@ -1,0 +1,58 @@
+# PermutiveAPI 6.5.1
+
+Released: 2026-08-06
+
+## Summary
+
+PermutiveAPI 6.5.1 makes the 6.5 AI-native platform verifiable from source checkout through published artifacts. It removes contract drift, simplifies onboarding and credentials, and establishes an explicit strict-typing boundary for canonical modules.
+
+## Product validation
+
+The CLI now provides deterministic lifecycle commands:
+
+- `permutiveapi validate`
+- `permutiveapi test`
+- `permutiveapi docs`
+- `permutiveapi examples`
+- `permutiveapi upgrade`
+- `permutiveapi uninstall`
+
+Installed-product validation checks package metadata, deterministic Python plugin discovery, and the public tool contract without credentials or network access.
+
+## Release truth
+
+Pull requests and releases now validate agreement between package version, dated changelog heading, release notes, and optional Git tag. Clean installations verify:
+
+- core SDK and CLI;
+- Python plugin entry point;
+- async extra;
+- dataframe extra;
+- PEP 561 marker and canonical module contents.
+
+## Onboarding and credentials
+
+The README now leads with the canonical synchronous and asynchronous clients, typed queries, optional extras, lifecycle CLI, and governed Codex plugin.
+
+Local configuration requires only `PERMUTIVE_API_KEY`, the authentication value consumed by the SDK and plugin. Workspace identifiers remain request data rather than global credentials.
+
+## Typing contract
+
+`TYPING_SCOPE.json` classifies every package module as either strict canonical code or an explicit compatibility module. CI requires the Pyright strict include list to match the canonical group exactly and prevents compatibility exclusions from silently growing.
+
+Downstream examples type-check canonical clients, queries, and the Codex plugin. The built wheel is checked for every strict implementation module and `py.typed`.
+
+## Compatibility
+
+This is a backward-compatible patch release. Existing synchronous, asynchronous, legacy resource, plugin, MCP, and agent APIs remain supported. No credential value is uploaded, echoed, or stored remotely.
+
+## Validation
+
+The release requires:
+
+- AI-native declaration and evidence validation;
+- release metadata and typing-scope validation;
+- Black and NumPy-style docstrings;
+- strict Pyright and downstream type consumption;
+- deterministic tests on Python 3.9–3.13;
+- wheel and source-distribution validation;
+- clean core, async, and dataframe installations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PermutiveAPI"
-version = "6.5.0"
+version = "6.5.1"
 description = "A typed, governed AI-native Python platform for the Permutive API."
 readme = "README.md"
 authors = [{ name = "FaTmamBo33", email = "fatmambo33@gmail.com" }]


### PR DESCRIPTION
Closes #185.
Advances #188 to the 6.6 milestone.

## Release scope

- version the package as 6.5.1
- publish complete product-validation, onboarding, credential, typing, and artifact notes
- record #190, #191, and #192 as completed
- move the active roadmap to #186, deterministic platform proof

## Compatibility

This is a backward-compatible patch release. Existing SDK, async, compatibility resource, plugin, MCP, and governed agent APIs remain supported.

## Validation and publication

- AI-native declarations and evidence: passed
- release metadata and typing scope: passed
- Black, NumPy docstrings, strict Pyright, and downstream type consumption: passed
- Python 3.9–3.13 tests and coverage: passed
- wheel and source-distribution validation: passed
- core, CLI, plugin, async, and dataframe clean installs: passed
- PyPI publication: passed
- package attestation and CycloneDX SBOM: passed
- tag and GitHub release `v6.5.1`: created
