### PR TITLE
Add a deterministic local Permutive mock server

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,13 +20,13 @@ The 6.5.1 patch release establishes verifiable product claims, truthful onboardi
 
 Tracking issue: #186
 
-- [ ] #196 — Deterministic policy, tool-selection, security, workflow, and audit scorecards.
+- [x] #196 — Deterministic policy, tool-selection, security, workflow, and audit scorecards.
 - [ ] #197 — Local mock Permutive server and reusable fixtures.
 - [ ] #198 — End-to-end governed agent scenarios.
 - [ ] #199 — Versioned capability negotiation across tools, plugin, and MCP.
 - [ ] #200 — Actionable errors, executable recipes, and first-success budget.
 
-The first slice makes agent guarantees executable and machine readable before adding broader integration scenarios.
+The scorecard now proves local governance. The active slice adds realistic HTTP behavior without requiring live credentials or external network access.
 
 ## Then — 6.7: operational reliability
 

--- a/TYPING_SCOPE.json
+++ b/TYPING_SCOPE.json
@@ -20,6 +20,7 @@
     "src/PermutiveAPI/query_dsl.py",
     "src/PermutiveAPI/resources.py",
     "src/PermutiveAPI/sdk.py",
+    "src/PermutiveAPI/testing.py",
     "src/PermutiveAPI/tools.py",
     "src/PermutiveAPI/validation.py"
   ],

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,74 @@
+# Local integration testing
+
+PermutiveAPI ships a standard-library loopback server for deterministic SDK and agent integration tests. It never contacts Permutive and requires no credentials.
+
+## Start the canonical fixtures
+
+```python
+from PermutiveAPI import PermutiveClient, RetryPolicy
+from PermutiveAPI.testing import MockPermutiveServer
+
+retry = RetryPolicy(
+    max_attempts=3,
+    initial_delay=0.001,
+    multiplier=1.0,
+    max_delay=0.001,
+    jitter=0.0,
+)
+
+with MockPermutiveServer.standard() as server:
+    with PermutiveClient(
+        "test-api-key",
+        base_url=server.base_url,
+        retry_policy=retry,
+    ) as client:
+        payload = client.request("GET", "v1/success")
+
+    requests = server.requests
+```
+
+The server binds only to `127.0.0.1` on an operating-system-selected port. Request logs are immutable snapshots and the server releases its socket when the context exits.
+
+## Version 1 scenarios
+
+`mock_fixtures/v1.json` is the machine-readable catalog for:
+
+- success and creation;
+- request validation failure;
+- authentication failure;
+- not found;
+- conflict;
+- rate-limit recovery;
+- temporary server recovery;
+- persistent server failure;
+- two-page iteration;
+- repeated continuation-token protection.
+
+Queued responses let the real retry implementation receive a failure followed by success. The final response remains reusable, which keeps repeated tests deterministic.
+
+## Custom routes
+
+```python
+from PermutiveAPI.testing import MockPermutiveServer, MockResponse, MockRoute
+
+routes = (
+    MockRoute(
+        method="GET",
+        path="/custom",
+        responses=(MockResponse(body={"state": "custom"}),),
+    ),
+)
+
+with MockPermutiveServer(routes) as server:
+    print(server.url("/custom"))
+```
+
+Routes are exact method-and-path matches. Query parameters and JSON bodies are captured in `MockRequest` records. Unknown routes return a deterministic JSON `404` response.
+
+## Sync and async parity
+
+The same server accepts both `PermutiveClient` and `AsyncPermutiveClient`. Tests should run equivalent success, error, retry, and pagination assertions against both clients rather than maintaining separate fake transports.
+
+## Fixture safety
+
+Fixture content must use synthetic identifiers and payloads. Do not copy production requests, credentials, workspace identifiers, or customer data into the catalog. Live integration tests remain opt-in under the `integration` marker.

--- a/mock_fixtures/v1.json
+++ b/mock_fixtures/v1.json
@@ -1,0 +1,155 @@
+{
+  "version": 1,
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/v1/success",
+      "responses": [
+        {
+          "status_code": 200,
+          "body": {"id": "fixture-success", "state": "ready"},
+          "headers": {}
+        }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/v1/create",
+      "responses": [
+        {
+          "status_code": 201,
+          "body": {"id": "fixture-created"},
+          "headers": {}
+        }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/v1/validation",
+      "responses": [
+        {
+          "status_code": 400,
+          "body": {"error": "invalid_fixture"},
+          "headers": {}
+        }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/v1/authentication",
+      "responses": [
+        {
+          "status_code": 401,
+          "body": {"error": "authentication_failed"},
+          "headers": {}
+        }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/v1/not-found",
+      "responses": [
+        {
+          "status_code": 404,
+          "body": {"error": "not_found"},
+          "headers": {}
+        }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/v1/conflict",
+      "responses": [
+        {
+          "status_code": 409,
+          "body": {"error": "conflict"},
+          "headers": {}
+        }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/v1/rate-limit",
+      "responses": [
+        {
+          "status_code": 429,
+          "body": {"error": "rate_limited"},
+          "headers": {"Retry-After": "0"}
+        },
+        {
+          "status_code": 200,
+          "body": {"state": "recovered", "attempt": 2},
+          "headers": {}
+        }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/v1/server-retry",
+      "responses": [
+        {
+          "status_code": 500,
+          "body": {"error": "temporary_failure"},
+          "headers": {}
+        },
+        {
+          "status_code": 200,
+          "body": {"state": "recovered", "attempt": 2},
+          "headers": {}
+        }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/v1/server-failure",
+      "responses": [
+        {
+          "status_code": 500,
+          "body": {"error": "server_failure"},
+          "headers": {}
+        }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/v1/pagination",
+      "responses": [
+        {
+          "status_code": 200,
+          "body": {
+            "items": [{"id": "page-1"}],
+            "continuation": "fixture-page-2"
+          },
+          "headers": {}
+        },
+        {
+          "status_code": 200,
+          "body": {"items": [{"id": "page-2"}]},
+          "headers": {}
+        }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/v1/repeated-token",
+      "responses": [
+        {
+          "status_code": 200,
+          "body": {
+            "items": [{"id": "repeat-1"}],
+            "continuation": "fixture-repeat"
+          },
+          "headers": {}
+        },
+        {
+          "status_code": 200,
+          "body": {
+            "items": [{"id": "repeat-2"}],
+            "continuation": "fixture-repeat"
+          },
+          "headers": {}
+        }
+      ]
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ include = [
     "tests",
     "typing_examples",
     "evals",
+    "mock_fixtures",
     "scripts",
     "docs",
     "README.md",
@@ -106,6 +107,7 @@ include = [
     "src/PermutiveAPI/query_dsl.py",
     "src/PermutiveAPI/resources.py",
     "src/PermutiveAPI/sdk.py",
+    "src/PermutiveAPI/testing.py",
     "src/PermutiveAPI/tools.py",
     "src/PermutiveAPI/validation.py",
 ]

--- a/src/PermutiveAPI/testing.py
+++ b/src/PermutiveAPI/testing.py
@@ -7,7 +7,7 @@ from collections import deque
 from dataclasses import dataclass, field
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from threading import Lock, Thread
-from typing import Deque, Dict, Mapping, Optional, Tuple, cast
+from typing import Any, Deque, Dict, Mapping, Optional, Protocol, Tuple, cast
 from urllib.parse import parse_qs, urlsplit
 
 from .sdk import JSONValue
@@ -67,6 +67,99 @@ class MockRequest:
     body: Optional[JSONValue]
 
 
+class _FixtureServerProtocol(Protocol):
+    """Server operations required by the request handler."""
+
+    def response_for(self, method: str, path: str) -> MockResponse:
+        """Return the next response for one request."""
+        ...
+
+    def record(self, request: MockRequest) -> None:
+        """Record one request."""
+        ...
+
+
+class _FixtureRequestHandler(BaseHTTPRequestHandler):
+    """Dispatch HTTP methods to the fixture server."""
+
+    server_version = "PermutiveAPIMock/1"
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib handler contract
+        self._handle()
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib handler contract
+        self._handle()
+
+    def do_PUT(self) -> None:  # noqa: N802 - stdlib handler contract
+        self._handle()
+
+    def do_PATCH(self) -> None:  # noqa: N802 - stdlib handler contract
+        self._handle()
+
+    def do_DELETE(self) -> None:  # noqa: N802 - stdlib handler contract
+        self._handle()
+
+    def do_HEAD(self) -> None:  # noqa: N802 - stdlib handler contract
+        self._handle(include_body=False)
+
+    def do_OPTIONS(self) -> None:  # noqa: N802 - stdlib handler contract
+        self._handle()
+
+    def log_message(self, format: str, *args: Any) -> None:
+        """Disable noisy request logging in deterministic tests."""
+        del format, args
+
+    def _handle(self, *, include_body: bool = True) -> None:
+        server = cast(_FixtureServerProtocol, self.server)
+        method = str(self.command)
+        parsed = urlsplit(self.path)
+        body = self._read_body()
+        request = MockRequest(
+            method=method,
+            path=parsed.path,
+            query={
+                key: tuple(values)
+                for key, values in parse_qs(
+                    parsed.query,
+                    keep_blank_values=True,
+                ).items()
+            },
+            headers={str(key): str(value) for key, value in self.headers.items()},
+            body=body,
+        )
+        server.record(request)
+        response = server.response_for(method, parsed.path)
+        encoded = (
+            json.dumps(response.body, sort_keys=True).encode("utf-8")
+            if response.body is not None
+            else b""
+        )
+        self.send_response(response.status_code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        for key, value in response.headers.items():
+            self.send_header(key, value)
+        self.end_headers()
+        if include_body and encoded:
+            self.wfile.write(encoded)
+
+    def _read_body(self) -> Optional[JSONValue]:
+        length_value = self.headers.get("Content-Length")
+        if length_value is None:
+            return None
+        try:
+            length = int(length_value)
+        except ValueError:
+            return None
+        if length <= 0:
+            return None
+        raw = self.rfile.read(length).decode("utf-8")
+        try:
+            return cast(JSONValue, json.loads(raw))
+        except json.JSONDecodeError:
+            return raw
+
+
 class _FixtureHTTPServer(ThreadingHTTPServer):
     """Threaded HTTP server with typed route queues and request capture."""
 
@@ -106,85 +199,6 @@ class _FixtureHTTPServer(ThreadingHTTPServer):
             return tuple(self._requests)
 
 
-class _FixtureRequestHandler(BaseHTTPRequestHandler):
-    """Dispatch HTTP methods to the fixture server."""
-
-    server_version = "PermutiveAPIMock/1"
-
-    def do_GET(self) -> None:  # noqa: N802 - stdlib handler contract
-        self._handle()
-
-    def do_POST(self) -> None:  # noqa: N802 - stdlib handler contract
-        self._handle()
-
-    def do_PUT(self) -> None:  # noqa: N802 - stdlib handler contract
-        self._handle()
-
-    def do_PATCH(self) -> None:  # noqa: N802 - stdlib handler contract
-        self._handle()
-
-    def do_DELETE(self) -> None:  # noqa: N802 - stdlib handler contract
-        self._handle()
-
-    def do_HEAD(self) -> None:  # noqa: N802 - stdlib handler contract
-        self._handle(include_body=False)
-
-    def do_OPTIONS(self) -> None:  # noqa: N802 - stdlib handler contract
-        self._handle()
-
-    def log_message(self, _format: str, *_args: object) -> None:
-        """Disable noisy request logging in deterministic tests."""
-
-    def _handle(self, *, include_body: bool = True) -> None:
-        server = cast(_FixtureHTTPServer, self.server)
-        parsed = urlsplit(self.path)
-        body = self._read_body()
-        request = MockRequest(
-            method=self.command,
-            path=parsed.path,
-            query={
-                key: tuple(values)
-                for key, values in parse_qs(
-                    parsed.query,
-                    keep_blank_values=True,
-                ).items()
-            },
-            headers={key: value for key, value in self.headers.items()},
-            body=body,
-        )
-        server.record(request)
-        response = server.response_for(self.command, parsed.path)
-        encoded = (
-            json.dumps(response.body, sort_keys=True).encode("utf-8")
-            if response.body is not None
-            else b""
-        )
-        self.send_response(response.status_code)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(encoded)))
-        for key, value in response.headers.items():
-            self.send_header(key, value)
-        self.end_headers()
-        if include_body and encoded:
-            self.wfile.write(encoded)
-
-    def _read_body(self) -> Optional[JSONValue]:
-        length_value = self.headers.get("Content-Length")
-        if length_value is None:
-            return None
-        try:
-            length = int(length_value)
-        except ValueError:
-            return None
-        if length <= 0:
-            return None
-        raw = self.rfile.read(length).decode("utf-8")
-        try:
-            return cast(JSONValue, json.loads(raw))
-        except json.JSONDecodeError:
-            return raw
-
-
 class MockPermutiveServer:
     """Run deterministic Permutive-like fixtures on a loopback HTTP server."""
 
@@ -200,8 +214,8 @@ class MockPermutiveServer:
     @property
     def base_url(self) -> str:
         """Return the active loopback base URL."""
-        address = cast(Tuple[str, int], self._server.server_address)
-        return f"http://{address[0]}:{address[1]}"
+        host, port = self._server.server_address
+        return f"http://{host}:{port}"
 
     @property
     def requests(self) -> Tuple[MockRequest, ...]:

--- a/src/PermutiveAPI/testing.py
+++ b/src/PermutiveAPI/testing.py
@@ -1,0 +1,348 @@
+"""Deterministic local HTTP fixtures for PermutiveAPI integrations."""
+
+from __future__ import annotations
+
+import json
+from collections import deque
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Lock, Thread
+from typing import Deque, Dict, Mapping, Optional, Tuple, cast
+from urllib.parse import parse_qs, urlsplit
+
+from .sdk import JSONValue
+
+MOCK_FIXTURE_VERSION = 1
+
+
+@dataclass(frozen=True)
+class MockResponse:
+    """Define one queued local HTTP response."""
+
+    status_code: int = 200
+    body: Optional[JSONValue] = None
+    headers: Mapping[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-compatible fixture representation."""
+        return {
+            "status_code": self.status_code,
+            "body": self.body,
+            "headers": dict(self.headers),
+        }
+
+
+@dataclass(frozen=True)
+class MockRoute:
+    """Map one method and path to one or more queued responses."""
+
+    method: str
+    path: str
+    responses: Tuple[MockResponse, ...]
+
+    def __post_init__(self) -> None:
+        """Validate the route contract."""
+        if not self.path.startswith("/"):
+            raise ValueError("Mock route paths must start with '/'.")
+        if not self.responses:
+            raise ValueError("Mock routes require at least one response.")
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-compatible fixture representation."""
+        return {
+            "method": self.method.upper(),
+            "path": self.path,
+            "responses": [response.to_dict() for response in self.responses],
+        }
+
+
+@dataclass(frozen=True)
+class MockRequest:
+    """Record one request received by the local server."""
+
+    method: str
+    path: str
+    query: Mapping[str, Tuple[str, ...]]
+    headers: Mapping[str, str]
+    body: Optional[JSONValue]
+
+
+class _FixtureHTTPServer(ThreadingHTTPServer):
+    """Threaded HTTP server with typed route queues and request capture."""
+
+    daemon_threads = True
+
+    def __init__(self, routes: Tuple[MockRoute, ...]) -> None:
+        super().__init__(("127.0.0.1", 0), _FixtureRequestHandler)
+        self._lock = Lock()
+        self._routes: Dict[Tuple[str, str], Deque[MockResponse]] = {
+            (route.method.upper(), route.path): deque(route.responses) for route in routes
+        }
+        self._requests: list[MockRequest] = []
+
+    def response_for(self, method: str, path: str) -> MockResponse:
+        """Return the next response, retaining the final response for reuse."""
+        key = (method.upper(), path)
+        with self._lock:
+            responses = self._routes.get(key)
+            if responses is None:
+                return MockResponse(
+                    status_code=404,
+                    body={"error": "mock_route_not_found", "path": path},
+                )
+            if len(responses) > 1:
+                return responses.popleft()
+            return responses[0]
+
+    def record(self, request: MockRequest) -> None:
+        """Append one immutable request record."""
+        with self._lock:
+            self._requests.append(request)
+
+    def request_snapshot(self) -> Tuple[MockRequest, ...]:
+        """Return an immutable request-log snapshot."""
+        with self._lock:
+            return tuple(self._requests)
+
+
+class _FixtureRequestHandler(BaseHTTPRequestHandler):
+    """Dispatch HTTP methods to the fixture server."""
+
+    server_version = "PermutiveAPIMock/1"
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib handler contract
+        self._handle()
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib handler contract
+        self._handle()
+
+    def do_PUT(self) -> None:  # noqa: N802 - stdlib handler contract
+        self._handle()
+
+    def do_PATCH(self) -> None:  # noqa: N802 - stdlib handler contract
+        self._handle()
+
+    def do_DELETE(self) -> None:  # noqa: N802 - stdlib handler contract
+        self._handle()
+
+    def do_HEAD(self) -> None:  # noqa: N802 - stdlib handler contract
+        self._handle(include_body=False)
+
+    def do_OPTIONS(self) -> None:  # noqa: N802 - stdlib handler contract
+        self._handle()
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        """Disable noisy request logging in deterministic tests."""
+
+    def _handle(self, *, include_body: bool = True) -> None:
+        server = cast(_FixtureHTTPServer, self.server)
+        parsed = urlsplit(self.path)
+        body = self._read_body()
+        request = MockRequest(
+            method=self.command,
+            path=parsed.path,
+            query={
+                key: tuple(values)
+                for key, values in parse_qs(
+                    parsed.query,
+                    keep_blank_values=True,
+                ).items()
+            },
+            headers={key: value for key, value in self.headers.items()},
+            body=body,
+        )
+        server.record(request)
+        response = server.response_for(self.command, parsed.path)
+        encoded = (
+            json.dumps(response.body, sort_keys=True).encode("utf-8")
+            if response.body is not None
+            else b""
+        )
+        self.send_response(response.status_code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        for key, value in response.headers.items():
+            self.send_header(key, value)
+        self.end_headers()
+        if include_body and encoded:
+            self.wfile.write(encoded)
+
+    def _read_body(self) -> Optional[JSONValue]:
+        length_value = self.headers.get("Content-Length")
+        if length_value is None:
+            return None
+        try:
+            length = int(length_value)
+        except ValueError:
+            return None
+        if length <= 0:
+            return None
+        raw = self.rfile.read(length).decode("utf-8")
+        try:
+            return cast(JSONValue, json.loads(raw))
+        except json.JSONDecodeError:
+            return raw
+
+
+class MockPermutiveServer:
+    """Run deterministic Permutive-like fixtures on a loopback HTTP server."""
+
+    def __init__(self, routes: Tuple[MockRoute, ...]) -> None:
+        self._server = _FixtureHTTPServer(routes)
+        self._thread: Optional[Thread] = None
+
+    @classmethod
+    def standard(cls) -> "MockPermutiveServer":
+        """Create a server with the canonical versioned fixture catalog."""
+        return cls(standard_mock_routes())
+
+    @property
+    def base_url(self) -> str:
+        """Return the active loopback base URL."""
+        address = cast(Tuple[str, int], self._server.server_address)
+        return f"http://{address[0]}:{address[1]}"
+
+    @property
+    def requests(self) -> Tuple[MockRequest, ...]:
+        """Return an immutable request-log snapshot."""
+        return self._server.request_snapshot()
+
+    def url(self, path: str) -> str:
+        """Build one absolute local fixture URL."""
+        return f"{self.base_url}/{path.lstrip('/')}"
+
+    def start(self) -> "MockPermutiveServer":
+        """Start the loopback server exactly once."""
+        if self._thread is not None:
+            return self
+        self._thread = Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    def close(self) -> None:
+        """Stop the server and release its loopback socket."""
+        if self._thread is None:
+            return
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5.0)
+        self._thread = None
+
+    def __enter__(self) -> "MockPermutiveServer":
+        """Start and return the local server context."""
+        return self.start()
+
+    def __exit__(self, *_: object) -> None:
+        """Close the local server context."""
+        self.close()
+
+
+def standard_mock_routes() -> Tuple[MockRoute, ...]:
+    """Return the canonical version 1 Permutive fixture routes."""
+    return (
+        MockRoute(
+            "GET",
+            "/v1/success",
+            (MockResponse(body={"id": "fixture-success", "state": "ready"}),),
+        ),
+        MockRoute(
+            "POST",
+            "/v1/create",
+            (MockResponse(status_code=201, body={"id": "fixture-created"}),),
+        ),
+        MockRoute(
+            "POST",
+            "/v1/validation",
+            (MockResponse(status_code=400, body={"error": "invalid_fixture"}),),
+        ),
+        MockRoute(
+            "GET",
+            "/v1/authentication",
+            (MockResponse(status_code=401, body={"error": "authentication_failed"}),),
+        ),
+        MockRoute(
+            "GET",
+            "/v1/not-found",
+            (MockResponse(status_code=404, body={"error": "not_found"}),),
+        ),
+        MockRoute(
+            "POST",
+            "/v1/conflict",
+            (MockResponse(status_code=409, body={"error": "conflict"}),),
+        ),
+        MockRoute(
+            "GET",
+            "/v1/rate-limit",
+            (
+                MockResponse(
+                    status_code=429,
+                    body={"error": "rate_limited"},
+                    headers={"Retry-After": "0"},
+                ),
+                MockResponse(body={"state": "recovered", "attempt": 2}),
+            ),
+        ),
+        MockRoute(
+            "GET",
+            "/v1/server-retry",
+            (
+                MockResponse(status_code=500, body={"error": "temporary_failure"}),
+                MockResponse(body={"state": "recovered", "attempt": 2}),
+            ),
+        ),
+        MockRoute(
+            "GET",
+            "/v1/server-failure",
+            (MockResponse(status_code=500, body={"error": "server_failure"}),),
+        ),
+        MockRoute(
+            "GET",
+            "/v1/pagination",
+            (
+                MockResponse(
+                    body={
+                        "items": [{"id": "page-1"}],
+                        "continuation": "fixture-page-2",
+                    }
+                ),
+                MockResponse(body={"items": [{"id": "page-2"}]}),
+            ),
+        ),
+        MockRoute(
+            "GET",
+            "/v1/repeated-token",
+            (
+                MockResponse(
+                    body={
+                        "items": [{"id": "repeat-1"}],
+                        "continuation": "fixture-repeat",
+                    }
+                ),
+                MockResponse(
+                    body={
+                        "items": [{"id": "repeat-2"}],
+                        "continuation": "fixture-repeat",
+                    }
+                ),
+            ),
+        ),
+    )
+
+
+def mock_fixture_catalog() -> dict[str, object]:
+    """Return the versioned machine-readable fixture catalog."""
+    return {
+        "version": MOCK_FIXTURE_VERSION,
+        "routes": [route.to_dict() for route in standard_mock_routes()],
+    }
+
+
+__all__ = [
+    "MOCK_FIXTURE_VERSION",
+    "MockPermutiveServer",
+    "MockRequest",
+    "MockResponse",
+    "MockRoute",
+    "mock_fixture_catalog",
+    "standard_mock_routes",
+]

--- a/src/PermutiveAPI/testing.py
+++ b/src/PermutiveAPI/testing.py
@@ -76,7 +76,8 @@ class _FixtureHTTPServer(ThreadingHTTPServer):
         super().__init__(("127.0.0.1", 0), _FixtureRequestHandler)
         self._lock = Lock()
         self._routes: Dict[Tuple[str, str], Deque[MockResponse]] = {
-            (route.method.upper(), route.path): deque(route.responses) for route in routes
+            (route.method.upper(), route.path): deque(route.responses)
+            for route in routes
         }
         self._requests: list[MockRequest] = []
 

--- a/tests/test_distribution_contract.py
+++ b/tests/test_distribution_contract.py
@@ -59,6 +59,7 @@ def test_wheel_contains_typed_package_and_plugin_metadata(tmp_path: Path) -> Non
         "PermutiveAPI/query_dsl.py",
         "PermutiveAPI/resources.py",
         "PermutiveAPI/sdk.py",
+        "PermutiveAPI/testing.py",
         "PermutiveAPI/tools.py",
         "PermutiveAPI/validation.py",
     }

--- a/tests/test_mock_server.py
+++ b/tests/test_mock_server.py
@@ -1,0 +1,163 @@
+"""Integration contracts for the deterministic local Permutive mock server."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from PermutiveAPI import (
+    AsyncPermutiveClient,
+    AuthenticationError,
+    ConflictError,
+    DecodingError,
+    NotFoundError,
+    PermutiveClient,
+    RetryPolicy,
+    ServerError,
+    ValidationError,
+)
+from PermutiveAPI.testing import MockPermutiveServer, mock_fixture_catalog
+
+
+@pytest.fixture
+def retry_policy() -> RetryPolicy:
+    """Return a fast deterministic retry policy for local HTTP tests."""
+    return RetryPolicy(
+        max_attempts=3,
+        initial_delay=0.001,
+        multiplier=1.0,
+        max_delay=0.001,
+        jitter=0.0,
+    )
+
+
+def test_fixture_catalog_matches_committed_version() -> None:
+    """The reusable JSON fixture catalog cannot drift from package routes."""
+    committed = json.loads(
+        Path("mock_fixtures/v1.json").read_text(encoding="utf-8")
+    )
+
+    assert committed == mock_fixture_catalog()
+
+
+def test_sync_client_success_and_request_capture(retry_policy: RetryPolicy) -> None:
+    """The canonical client can use the loopback server without test adapters."""
+    with MockPermutiveServer.standard() as server:
+        with PermutiveClient(
+            "test-api-key",
+            base_url=server.base_url,
+            retry_policy=retry_policy,
+        ) as client:
+            payload = client.request("GET", "v1/success")
+            created = client.request(
+                "POST",
+                "v1/create",
+                json={"name": "fixture"},
+            )
+
+    assert payload == {"id": "fixture-success", "state": "ready"}
+    assert created == {"id": "fixture-created"}
+    assert [request.path for request in server.requests] == [
+        "/v1/success",
+        "/v1/create",
+    ]
+    assert server.requests[0].query["k"] == ("test-api-key",)
+    assert server.requests[1].body == {"name": "fixture"}
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "error_type"),
+    (
+        ("POST", "v1/validation", ValidationError),
+        ("GET", "v1/authentication", AuthenticationError),
+        ("GET", "v1/not-found", NotFoundError),
+        ("POST", "v1/conflict", ConflictError),
+        ("GET", "v1/server-failure", ServerError),
+    ),
+)
+def test_sync_error_mapping(
+    method: str,
+    path: str,
+    error_type: type[Exception],
+    retry_policy: RetryPolicy,
+) -> None:
+    """Representative fixture failures map through canonical SDK exceptions."""
+    with MockPermutiveServer.standard() as server:
+        with PermutiveClient(
+            "test-api-key",
+            base_url=server.base_url,
+            retry_policy=retry_policy,
+        ) as client:
+            with pytest.raises(error_type):
+                client.request(method, path)
+
+
+def test_sync_retries_rate_limits_and_server_errors(
+    retry_policy: RetryPolicy,
+) -> None:
+    """Queued responses deterministically exercise successful retries."""
+    with MockPermutiveServer.standard() as server:
+        with PermutiveClient(
+            "test-api-key",
+            base_url=server.base_url,
+            retry_policy=retry_policy,
+        ) as client:
+            rate_limit = client.request("GET", "v1/rate-limit")
+            server_retry = client.request("GET", "v1/server-retry")
+
+    assert rate_limit == {"state": "recovered", "attempt": 2}
+    assert server_retry == {"state": "recovered", "attempt": 2}
+    assert [request.path for request in server.requests].count("/v1/rate-limit") == 2
+    assert [request.path for request in server.requests].count("/v1/server-retry") == 2
+
+
+def test_sync_pagination_and_repeated_token_guard(
+    retry_policy: RetryPolicy,
+) -> None:
+    """The local fixtures cover complete and malformed continuation flows."""
+    with MockPermutiveServer.standard() as server:
+        with PermutiveClient(
+            "test-api-key",
+            base_url=server.base_url,
+            retry_policy=retry_policy,
+        ) as client:
+            items = list(
+                client.iter_all(
+                    "v1/pagination",
+                    item_decoder=lambda item: item,
+                )
+            )
+            with pytest.raises(DecodingError, match="Repeated pagination"):
+                list(
+                    client.iter_all(
+                        "v1/repeated-token",
+                        item_decoder=lambda item: item,
+                    )
+                )
+
+    assert items == [{"id": "page-1"}, {"id": "page-2"}]
+
+
+@pytest.mark.asyncio
+async def test_async_client_matches_sync_retry_and_capture(
+    retry_policy: RetryPolicy,
+) -> None:
+    """The HTTPX async client observes the same local retry contract."""
+    with MockPermutiveServer.standard() as server:
+        async with AsyncPermutiveClient(
+            "test-api-key",
+            base_url=server.base_url,
+            retry_policy=retry_policy,
+        ) as client:
+            success = await client.request("GET", "v1/success")
+            recovered = await client.request("GET", "v1/rate-limit")
+
+    assert success == {"id": "fixture-success", "state": "ready"}
+    assert recovered == {"state": "recovered", "attempt": 2}
+    assert [request.path for request in server.requests] == [
+        "/v1/success",
+        "/v1/rate-limit",
+        "/v1/rate-limit",
+    ]

--- a/tests/test_mock_server.py
+++ b/tests/test_mock_server.py
@@ -35,9 +35,7 @@ def retry_policy() -> RetryPolicy:
 
 def test_fixture_catalog_matches_committed_version() -> None:
     """The reusable JSON fixture catalog cannot drift from package routes."""
-    committed = json.loads(
-        Path("mock_fixtures/v1.json").read_text(encoding="utf-8")
-    )
+    committed = json.loads(Path("mock_fixtures/v1.json").read_text(encoding="utf-8"))
 
     assert committed == mock_fixture_catalog()
 


### PR DESCRIPTION
Closes #197.
Advances #186 and #188.

## What changed

- add a strictly typed standard-library loopback HTTP server
- add exact method-and-path routes, queued retry responses, and immutable request capture
- publish a versioned v1 fixture catalog for success, creation, validation, authentication, not found, conflict, rate limits, server failures, pagination, and repeated tokens
- exercise the real synchronous and HTTPX asynchronous clients against the same fixtures
- verify canonical error mapping, retry recovery, pagination completion, and repeated-token protection
- keep the server dependency-free, credential-free, and bound to `127.0.0.1`
- include the testing module in strict typing and wheel-content contracts
- include reusable fixture evidence and testing documentation in source distributions

## Product impact

SDK, plugin, workflow, and evaluation tests can now use realistic local HTTP behavior without live credentials, external network access, or duplicated fake transports.

## Validation

- AI-native platform gate: passed
- formatting and NumPy docstrings: passed
- strict Pyright and downstream typing: passed
- Python 3.9–3.13 tests: passed
- real sync and HTTPX async loopback parity: passed
- fixture catalog equality: passed
- package build, Twine, and clean installs: passed
- async and dataframe optional extras: passed
