### PR TITLE
chore: adopt AI-native platform v0.1 contract

### DIFF
--- a/.github/workflows/ai-native-platform.yml
+++ b/.github/workflows/ai-native-platform.yml
@@ -15,13 +15,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: '3.12'
           cache: pip
-      - name: Install validation dependencies
+      - name: Install project and validation dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e . PyYAML
-      - name: Validate declarations and repository evidence
+          python -m pip install --disable-pip-version-check -e .
+          python -m pip install --disable-pip-version-check 'jsonschema>=4.23,<5' 'PyYAML>=6,<7'
+      - name: Validate the pinned AI-native contract and repository evidence
         run: python scripts/validate_ai_native_platform.py
       - name: Validate installed product surface
         run: permutiveapi validate

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,15 +8,25 @@ on:
     - cron: '23 5 * * 1'
 
 permissions:
+  actions: read
   contents: read
-  security-events: write
 
 jobs:
-  codeql:
+  codeql-artifact:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: github/codeql-action/init@v4
         with:
           languages: python
-      - uses: github/codeql-action/analyze@v4
+      - name: Analyze without duplicating GitHub default setup
+        uses: github/codeql-action/analyze@v4
+        with:
+          output: ../codeql-results
+          upload: never
+      - name: Retain CodeQL SARIF
+        uses: actions/upload-artifact@v4
+        with:
+          name: codeql-sarif-${{ github.sha }}
+          path: ../codeql-results/*.sarif
+          retention-days: 14

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   actions: read
   contents: read
+  security-events: read
 
 jobs:
   codeql-artifact:
@@ -22,11 +23,11 @@ jobs:
       - name: Analyze without duplicating GitHub default setup
         uses: github/codeql-action/analyze@v4
         with:
-          output: ../codeql-results
+          output: codeql-results
           upload: never
       - name: Retain CodeQL SARIF
         uses: actions/upload-artifact@v4
         with:
           name: codeql-sarif-${{ github.sha }}
-          path: ../codeql-results/*.sarif
+          path: codeql-results/*.sarif
           retention-days: 14

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,22 @@
+name: Security
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '23 5 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  codeql:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v4
+        with:
+          languages: python
+      - uses: github/codeql-action/analyze@v4

--- a/AI_NATIVE_PLATFORM.yaml
+++ b/AI_NATIVE_PLATFORM.yaml
@@ -1,18 +1,47 @@
 version: 1
-
 standard:
   repository: fatmambot33/ai-native-platform
-  ref: 67ec7caf19ead3282ea1aad29c43906f59e64d67
-
+  ref: 585484a227741a9eac78393e631b9d3794b85ec8
+quality:
+  typed: true
+  tests: true
+  docs: true
+  examples: true
+  compatibility: true
+  security_scan: true
+release:
+  block_if_quality_fails: true
+  block_if_plugin_invalid: true
+agent:
+  guarantees:
+  - deterministic_tool_discovery
+  - structured_outputs
+  - issue_driven_improvement
+  - ci_validated_changes
+  - governed_autonomy
+self_improvement:
+  enabled: true
+  github:
+    issues: true
+  autonomous:
+    discover_improvements: true
+    create_issues: true
+    generate_pr: true
+    run_ci: true
+  governance:
+    human_approval:
+      breaking_changes: true
+      security_changes: true
+      credential_changes: true
+      public_api_changes: true
+      permission_expansion: true
+      release_changes: true
 product:
   name: PermutiveAPI
+  profile: full-platform
   ai_native: true
-  plugin_first: true
-  sdk_first: true
-  api_first: true
-  cli_first: true
-  mcp_first: true
-
+  description: Typed Permutive SDK, CLI, MCP, and Codex plugin with governed write
+    operations.
 plugin:
   enabled: true
   codex:
@@ -27,71 +56,41 @@ plugin:
     local_only: true
     env_file: .env
     env_example: plugins/permutiveapi/.env.example
-    required_variables: [PERMUTIVE_API_KEY]
     setup_command: permutiveapi configure
     validation_command: permutiveapi doctor
+    required_variables:
+    - PERMUTIVE_API_KEY
     policy:
       never_store_remote: true
       never_commit: true
       never_echo: true
-      require_gitignore: true
-      require_local_env: true
-
-commands:
-  required: [configure, doctor, validate, test, eval, docs, examples, upgrade, uninstall]
-  recommended: [benchmark]
-
 interfaces:
   sdk: true
   cli: true
   plugin: true
-  mcp: true
-  openai_tools: true
   json_schema: true
-
-quality:
-  typed: true
-  tests: true
-  docs: true
-  examples: true
-  security_scan: true
-  compatibility_tests: true
-  ai_evaluations: true
-  benchmark: false
-
-self_improvement:
-  enabled: true
-  github:
-    issues: true
-  autonomous:
-    discover_improvements: true
-    create_issues: true
-    generate_pr: true
-    run_ci: true
-    update_roadmap_and_changelog: true
-  governance:
-    human_approval:
-      breaking_changes: true
-      security_changes: true
-      credential_changes: true
-      public_api_changes: true
-      permission_expansion: true
-      release_changes: true
-    safe_auto_merge: [documentation, tests, formatting, examples, non_breaking_maintenance]
-
-release:
-  block_if_quality_fails: true
-  block_if_doctor_fails: true
-  block_if_plugin_invalid: true
-  block_if_self_improvement_contract_invalid: true
-
-agent:
-  guarantees:
-    - local_credentials_only
-    - no_remote_secret_storage
-    - human_confirmation_for_writes
-    - deterministic_tool_discovery
-    - structured_outputs
-    - issue_driven_improvement
-    - ci_validated_changes
-    - governed_autonomy
+  mcp: true
+  openapi: false
+evidence:
+  mode: repository
+  paths:
+    readme: README.md
+    tests: tests
+    agent_instructions: AGENTS.md
+    typing: pyproject.toml
+    ci: .github/workflows/ci.yml
+    sdk: src/PermutiveAPI
+    cli: src/PermutiveAPI/cli.py
+    schemas: schemas/ai-native-platform.schema.json
+    mcp: src/PermutiveAPI/mcp.py
+    plugin_manifest: plugins/permutiveapi/.codex-plugin/plugin.json
+    plugin_tests:
+    - tests/test_codex_plugin_surface.py
+    - tests/test_plugins.py
+    docs: docs
+    examples: examples
+    security_workflow: .github/workflows/security.yml
+    env_example: plugins/permutiveapi/.env.example
+    gitignore: .gitignore
+    self_improvement_workflow: .github/workflows/ai-self-improvement.yml
+    improvement_issue_template: .github/ISSUE_TEMPLATE/ai-improvement.yml

--- a/AI_NATIVE_PLATFORM.yaml
+++ b/AI_NATIVE_PLATFORM.yaml
@@ -88,7 +88,7 @@ evidence:
     - tests/test_codex_plugin_surface.py
     - tests/test_plugins.py
     docs: docs
-    examples: examples
+    examples: README.md
     security_workflow: .github/workflows/security.yml
     env_example: plugins/permutiveapi/.env.example
     gitignore: .gitignore

--- a/schemas/ai-native-platform.schema.json
+++ b/schemas/ai-native-platform.schema.json
@@ -1,0 +1,420 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/fatmambot33/ai-native-platform/schemas/ai-native-platform.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "standard",
+    "product",
+    "plugin",
+    "interfaces",
+    "quality",
+    "release",
+    "agent",
+    "self_improvement",
+    "evidence"
+  ],
+  "$defs": {
+    "pathValue": {
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        }
+      ]
+    }
+  },
+  "properties": {
+    "version": {
+      "const": 1
+    },
+    "standard": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repository",
+        "ref"
+      ],
+      "properties": {
+        "repository": {
+          "const": "fatmambot33/ai-native-platform"
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "product": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "profile",
+        "ai_native"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "profile": {
+          "enum": [
+            "library",
+            "cli",
+            "service",
+            "agent-tool",
+            "plugin",
+            "full-platform"
+          ]
+        },
+        "ai_native": {
+          "const": true
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "plugin": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "enabled",
+        "codex",
+        "discovery",
+        "credentials"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "codex": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "supported",
+            "marketplace"
+          ],
+          "properties": {
+            "supported": {
+              "type": "boolean"
+            },
+            "marketplace": {
+              "type": "boolean"
+            }
+          }
+        },
+        "discovery": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "entry_points",
+            "manifest",
+            "capabilities"
+          ],
+          "properties": {
+            "entry_points": {
+              "type": "boolean"
+            },
+            "manifest": {
+              "type": "boolean"
+            },
+            "capabilities": {
+              "type": "boolean"
+            }
+          }
+        },
+        "credentials": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "required",
+            "local_only",
+            "policy"
+          ],
+          "properties": {
+            "required": {
+              "type": "boolean"
+            },
+            "local_only": {
+              "const": true
+            },
+            "env_file": {
+              "type": "string",
+              "minLength": 1
+            },
+            "env_example": {
+              "type": "string",
+              "minLength": 1
+            },
+            "setup_command": {
+              "type": "string",
+              "minLength": 1
+            },
+            "validation_command": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required_variables": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "uniqueItems": true
+            },
+            "policy": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "never_store_remote",
+                "never_commit",
+                "never_echo"
+              ],
+              "properties": {
+                "never_store_remote": {
+                  "const": true
+                },
+                "never_commit": {
+                  "const": true
+                },
+                "never_echo": {
+                  "const": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "interfaces": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sdk",
+        "cli",
+        "plugin",
+        "json_schema",
+        "mcp",
+        "openapi"
+      ],
+      "properties": {
+        "sdk": {
+          "type": "boolean"
+        },
+        "cli": {
+          "type": "boolean"
+        },
+        "plugin": {
+          "type": "boolean"
+        },
+        "json_schema": {
+          "type": "boolean"
+        },
+        "mcp": {
+          "type": "boolean"
+        },
+        "openapi": {
+          "type": "boolean"
+        }
+      }
+    },
+    "quality": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "typed",
+        "tests",
+        "docs",
+        "examples",
+        "compatibility",
+        "security_scan"
+      ],
+      "properties": {
+        "typed": {
+          "const": true
+        },
+        "tests": {
+          "const": true
+        },
+        "docs": {
+          "const": true
+        },
+        "examples": {
+          "const": true
+        },
+        "compatibility": {
+          "const": true
+        },
+        "security_scan": {
+          "const": true
+        }
+      }
+    },
+    "release": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "block_if_quality_fails",
+        "block_if_plugin_invalid"
+      ],
+      "properties": {
+        "block_if_quality_fails": {
+          "const": true
+        },
+        "block_if_plugin_invalid": {
+          "const": true
+        }
+      }
+    },
+    "agent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "guarantees"
+      ],
+      "properties": {
+        "guarantees": {
+          "type": "array",
+          "uniqueItems": true,
+          "minItems": 5,
+          "items": {
+            "enum": [
+              "ci_validated_changes",
+              "deterministic_tool_discovery",
+              "governed_autonomy",
+              "issue_driven_improvement",
+              "structured_outputs"
+            ]
+          }
+        }
+      }
+    },
+    "self_improvement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "enabled",
+        "github",
+        "autonomous",
+        "governance"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "github": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "issues"
+          ],
+          "properties": {
+            "issues": {
+              "type": "boolean"
+            }
+          }
+        },
+        "autonomous": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "discover_improvements",
+            "create_issues",
+            "generate_pr",
+            "run_ci"
+          ],
+          "properties": {
+            "discover_improvements": {
+              "type": "boolean"
+            },
+            "create_issues": {
+              "type": "boolean"
+            },
+            "generate_pr": {
+              "type": "boolean"
+            },
+            "run_ci": {
+              "type": "boolean"
+            }
+          }
+        },
+        "governance": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "human_approval"
+          ],
+          "properties": {
+            "human_approval": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "breaking_changes",
+                "security_changes",
+                "credential_changes",
+                "public_api_changes",
+                "permission_expansion",
+                "release_changes"
+              ],
+              "properties": {
+                "breaking_changes": {
+                  "const": true
+                },
+                "security_changes": {
+                  "const": true
+                },
+                "credential_changes": {
+                  "const": true
+                },
+                "public_api_changes": {
+                  "const": true
+                },
+                "permission_expansion": {
+                  "const": true
+                },
+                "release_changes": {
+                  "const": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "paths"
+      ],
+      "properties": {
+        "mode": {
+          "const": "repository"
+        },
+        "paths": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/pathValue"
+          }
+        }
+      }
+    },
+    "extensions": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/scripts/validate_ai_native_platform.py
+++ b/scripts/validate_ai_native_platform.py
@@ -1,56 +1,20 @@
-"""Validate declarations and concrete AI-native repository evidence."""
+"""Validate the repository against the pinned AI-native platform contract."""
 
 from __future__ import annotations
 
+import json
 import re
+from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 import yaml
+from jsonschema import Draft202012Validator
 
-ROOT = Path(".")
+ROOT = Path(__file__).resolve().parents[1]
 MANIFEST = ROOT / "AI_NATIVE_PLATFORM.yaml"
-STANDARD_REPOSITORY = "fatmambot33/ai-native-platform"
-REQUIRED_TRUE_PATHS = (
-    ("product", "ai_native"),
-    ("product", "plugin_first"),
-    ("product", "sdk_first"),
-    ("plugin", "enabled"),
-    ("plugin", "codex", "supported"),
-    ("plugin", "codex", "marketplace"),
-    ("plugin", "discovery", "entry_points"),
-    ("plugin", "discovery", "manifest"),
-    ("plugin", "discovery", "capabilities"),
-    ("plugin", "credentials", "local_only"),
-    ("plugin", "credentials", "policy", "never_store_remote"),
-    ("plugin", "credentials", "policy", "never_commit"),
-    ("plugin", "credentials", "policy", "never_echo"),
-    ("interfaces", "sdk"),
-    ("interfaces", "cli"),
-    ("interfaces", "plugin"),
-    ("interfaces", "json_schema"),
-    ("quality", "typed"),
-    ("quality", "tests"),
-    ("quality", "docs"),
-    ("quality", "examples"),
-    ("quality", "security_scan"),
-    ("self_improvement", "enabled"),
-    ("self_improvement", "github", "issues"),
-    ("self_improvement", "autonomous", "discover_improvements"),
-    ("self_improvement", "autonomous", "create_issues"),
-    ("self_improvement", "autonomous", "generate_pr"),
-    ("self_improvement", "autonomous", "run_ci"),
-    ("release", "block_if_quality_fails"),
-    ("release", "block_if_plugin_invalid"),
-)
-REQUIRED_COMMANDS = {
-    "validate",
-    "test",
-    "docs",
-    "examples",
-    "upgrade",
-    "uninstall",
-}
+SCHEMA = ROOT / "schemas/ai-native-platform.schema.json"
+IMMUTABLE_REF = re.compile(r"(?:[0-9a-f]{40}|v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)")
 REQUIRED_GUARANTEES = {
     "deterministic_tool_discovery",
     "structured_outputs",
@@ -58,206 +22,157 @@ REQUIRED_GUARANTEES = {
     "ci_validated_changes",
     "governed_autonomy",
 }
-REQUIRED_APPROVALS = {
-    "breaking_changes",
-    "security_changes",
-    "credential_changes",
-    "public_api_changes",
-    "permission_expansion",
-    "release_changes",
+PROFILE_REQUIREMENTS: dict[str, tuple[str, ...]] = {
+    "library": ("interfaces.sdk", "interfaces.json_schema"),
+    "cli": ("interfaces.cli", "interfaces.json_schema"),
+    "plugin": ("interfaces.plugin", "plugin.enabled", "interfaces.json_schema"),
+    "agent-tool": ("interfaces.json_schema",),
+    "service": ("interfaces.json_schema",),
+    "full-platform": (
+        "interfaces.sdk",
+        "interfaces.cli",
+        "interfaces.plugin",
+        "plugin.enabled",
+        "interfaces.json_schema",
+    ),
 }
+BASE_EVIDENCE = {"readme", "tests", "agent_instructions", "typing", "ci"}
 
 
-def read_path(data: dict[str, Any], path: tuple[str, ...]) -> Any:
-    """Read one nested manifest value."""
-    current: Any = data
-    for key in path:
-        if not isinstance(current, dict) or key not in current:
-            raise KeyError(".".join(path))
-        current = current[key]
-    return current
+def read_path(data: Mapping[str, Any], dotted: str) -> Any:
+    """Read one dotted path from a nested mapping."""
+    value: Any = data
+    for part in dotted.split("."):
+        if not isinstance(value, Mapping) or part not in value:
+            raise KeyError(dotted)
+        value = value[part]
+    return value
 
 
-def matching(patterns: Iterable[str]) -> list[Path]:
-    """Return matching repository files."""
-    return sorted(
-        {
-            path
-            for pattern in patterns
-            for path in ROOT.glob(pattern)
-            if path.is_file() and ".git" not in path.parts
-        }
-    )
-
-
-def text(paths: Iterable[Path]) -> str:
-    """Read small text files as lowercase text."""
-    return "\n".join(
-        path.read_text(encoding="utf-8", errors="ignore")
-        for path in paths
-        if path.stat().st_size < 2_000_000
-    ).lower()
-
-
-def _command_is_implemented(cli_text: str, command: str) -> bool:
-    """Return whether one declared command appears in the CLI parser contract."""
-    quoted = (f'"{command}"', f"'{command}'")
-    return any(value in cli_text for value in quoted) and "add_parser" in cli_text
-
-
-def evidence(data: dict[str, Any]) -> list[str]:
-    """Return missing evidence labels."""
-    readmes = matching(("README.md", "docs/**/*.md"))
-    source = matching(("src/**/*.py", "**/plugins/**/*.py", "plugins/**/*.py"))
-    workflows = matching((".github/workflows/*.yml", ".github/workflows/*.yaml"))
-    tests = matching(("tests/test_*.py", "tests/**/*test*.py"))
-    docs = text(readmes)
-    code = text(source)
-    ci = text(workflows)
-    pyproject = ROOT / "pyproject.toml"
-    cli_path = ROOT / "src/PermutiveAPI/cli.py"
-    cli_text = (
-        cli_path.read_text(encoding="utf-8", errors="ignore").lower()
-        if cli_path.is_file()
-        else ""
-    )
-    checks = {
-        "pyproject.toml": pyproject.is_file(),
-        "Codex plugin manifest": bool(
-            matching(
-                (
-                    ".codex-plugin/plugin.json",
-                    "plugins/**/.codex-plugin/plugin.json",
-                )
-            )
-        ),
-        "Codex marketplace catalog": bool(
-            matching((".agents/plugins/marketplace.json", "plugins/**/marketplace.json"))
-        ),
-        "typed plugin contract": "plugin" in code
-        and ("protocol" in code or "abstractbaseclass" in code),
-        "typing marker or explicit Pyright contract": bool(
-            matching(("src/**/py.typed", "**/py.typed"))
-        )
-        or "pyright" in text([pyproject]),
-        "strict type checking in CI": "pyright" in ci or "mypy" in ci,
-        "plugin tests": any("plugin" in path.name.lower() for path in tests),
-        "general tests": bool(tests),
-        "AGENTS.md": (ROOT / "AGENTS.md").is_file(),
-        "PyPI installation documentation": "pip install" in docs,
-        "Git installation documentation": "git+https://" in docs
-        or "git clone" in docs,
-        "editable installation documentation": "pip install -e" in docs,
-        "plugin documentation": "plugin" in docs and "codex" in docs,
-        "AI improvement issue template": (
-            ROOT / ".github/ISSUE_TEMPLATE/ai-improvement.yml"
-        ).is_file(),
-        "self-improvement workflow": (
-            ROOT / ".github/workflows/ai-self-improvement.yml"
-        ).is_file()
-        or (ROOT / ".github/workflows/ai-self-improve.yml").is_file(),
-    }
-    declared_commands = set(data.get("commands", {}).get("required", []))
-    for command in sorted(declared_commands):
-        checks[f"implemented CLI command: {command}"] = _command_is_implemented(
-            cli_text,
-            command,
-        )
-
+def required_evidence(data: Mapping[str, Any]) -> set[str]:
+    """Return evidence keys implied by declared capabilities."""
+    keys = set(BASE_EVIDENCE)
+    interfaces = data.get("interfaces", {})
     quality = data.get("quality", {})
-    if quality.get("ai_evaluations") is True:
-        checks["AI evaluation harness"] = bool(
-            matching(("evals/**/*.py", "tests/**/*eval*.py", "tests/test_eval*.py"))
-        )
-    if quality.get("benchmark") is True:
-        checks["benchmark suite"] = bool(
-            matching(("benchmarks/**/*.py", "tests/**/*benchmark*.py"))
-        ) or "pytest-benchmark" in text([pyproject])
+    plugin = data.get("plugin", {})
+    improvement = data.get("self_improvement", {})
 
-    credentials = data.get("plugin", {}).get("credentials", {})
-    if credentials.get("required"):
-        env_example = credentials.get("env_example")
-        checks["credential template"] = isinstance(env_example, str) and (
-            ROOT / env_example
-        ).is_file()
-        checks["configure command"] = bool(credentials.get("setup_command"))
-        checks["doctor command"] = bool(credentials.get("validation_command"))
-        checks[".env ignored"] = (ROOT / ".gitignore").is_file() and ".env" in (
-            ROOT / ".gitignore"
-        ).read_text(encoding="utf-8", errors="ignore")
-    return [label for label, passed in checks.items() if not passed]
+    if isinstance(interfaces, Mapping):
+        for capability, evidence_key in {
+            "sdk": "sdk",
+            "cli": "cli",
+            "json_schema": "schemas",
+            "mcp": "mcp",
+            "openapi": "openapi",
+        }.items():
+            if interfaces.get(capability) is True:
+                keys.add(evidence_key)
+        if interfaces.get("plugin") is True:
+            keys.update({"plugin_manifest", "plugin_tests"})
+
+    if isinstance(quality, Mapping):
+        if quality.get("docs") is True:
+            keys.add("docs")
+        if quality.get("examples") is True:
+            keys.add("examples")
+        if quality.get("security_scan") is True:
+            keys.add("security_workflow")
+
+    if isinstance(plugin, Mapping):
+        credentials = plugin.get("credentials", {})
+        if isinstance(credentials, Mapping) and credentials.get("required") is True:
+            keys.update({"env_example", "gitignore"})
+
+    if isinstance(improvement, Mapping) and improvement.get("enabled") is True:
+        keys.update({"self_improvement_workflow", "improvement_issue_template"})
+    return keys
+
+
+def declarations(value: Any) -> list[str]:
+    """Normalize an evidence declaration to repository-relative paths."""
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return [item for item in value if isinstance(item, str)]
+    return []
+
+
+def path_exists(declaration: str) -> bool:
+    """Return whether one repository-relative path or glob exists."""
+    path = Path(declaration)
+    if path.is_absolute() or ".." in path.parts:
+        return False
+    if any(character in declaration for character in "*?["):
+        return any(ROOT.glob(declaration))
+    return (ROOT / declaration).exists()
+
+
+def validate() -> list[str]:
+    """Return deterministic contract and evidence errors."""
+    data = yaml.safe_load(MANIFEST.read_text(encoding="utf-8"))
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or not isinstance(schema, dict):
+        return ["manifest and schema must contain mappings"]
+
+    errors = []
+    validator = Draft202012Validator(schema)
+    for error in sorted(validator.iter_errors(data), key=lambda item: list(item.absolute_path)):
+        location = ".".join(str(part) for part in error.absolute_path) or "manifest"
+        errors.append(f"schema [{location}]: {error.message}")
+
+    standard = data.get("standard", {})
+    if isinstance(standard, Mapping):
+        reference = str(standard.get("ref", ""))
+        if IMMUTABLE_REF.fullmatch(reference) is None:
+            errors.append("standard.ref must be an immutable version or commit SHA")
+
+    product = data.get("product", {})
+    profile = product.get("profile") if isinstance(product, Mapping) else None
+    if isinstance(profile, str):
+        for requirement in PROFILE_REQUIREMENTS.get(profile, ()):
+            try:
+                if read_path(data, requirement) is not True:
+                    errors.append(f"{profile} requires {requirement}=true")
+            except KeyError:
+                errors.append(f"{profile} requires {requirement}")
+        interfaces = data.get("interfaces", {})
+        if isinstance(interfaces, Mapping):
+            if profile == "agent-tool" and not (
+                interfaces.get("plugin") is True or interfaces.get("mcp") is True
+            ):
+                errors.append("agent-tool requires a plugin or MCP interface")
+            if profile == "service" and not (
+                interfaces.get("openapi") is True or interfaces.get("sdk") is True
+            ):
+                errors.append("service requires an OpenAPI or SDK interface")
+
+    agent = data.get("agent", {})
+    guarantees = set(agent.get("guarantees", [])) if isinstance(agent, Mapping) else set()
+    for guarantee in sorted(REQUIRED_GUARANTEES - guarantees):
+        errors.append(f"missing agent guarantee: {guarantee}")
+
+    evidence = data.get("evidence", {})
+    paths = evidence.get("paths", {}) if isinstance(evidence, Mapping) else {}
+    if not isinstance(paths, Mapping):
+        errors.append("evidence.paths must be a mapping")
+        return errors
+    for key in sorted(required_evidence(data)):
+        declared = declarations(paths.get(key))
+        if not declared:
+            errors.append(f"missing evidence declaration: {key}")
+            continue
+        missing = [item for item in declared if not path_exists(item)]
+        if missing:
+            errors.append(f"missing evidence for {key}: {', '.join(missing)}")
+    return errors
 
 
 def main() -> int:
-    """Validate the local manifest and repository evidence."""
-    data = (
-        yaml.safe_load(MANIFEST.read_text(encoding="utf-8"))
-        if MANIFEST.is_file()
-        else None
-    )
-    if not isinstance(data, dict) or data.get("version") != 1:
-        print(
-            "AI-native platform validation failed:\n"
-            "- missing or invalid version 1 manifest"
-        )
-        return 1
-    errors: list[str] = []
-    standard = data.get("standard", {})
-    if standard.get("repository") != STANDARD_REPOSITORY:
-        errors.append(f"standard.repository must be {STANDARD_REPOSITORY}")
-    if not re.fullmatch(
-        r"[0-9a-f]{40}|v?\d+\.\d+\.\d+",
-        str(standard.get("ref", "")),
-    ):
-        errors.append("standard.ref must pin an immutable commit or semantic version")
-    for path in REQUIRED_TRUE_PATHS:
-        try:
-            if read_path(data, path) is not True:
-                errors.append(f"{'.'.join(path)} must be true")
-        except KeyError:
-            errors.append(f"missing {'.'.join(path)}")
-    commands = set(data.get("commands", {}).get("required", []))
-    errors.extend(
-        f"commands.required must include {item}"
-        for item in sorted(REQUIRED_COMMANDS - commands)
-    )
-    credentials = data.get("plugin", {}).get("credentials", {})
-    if credentials.get("required"):
-        errors.extend(
-            f"plugin.credentials.{field} is required"
-            for field in (
-                "env_file",
-                "env_example",
-                "setup_command",
-                "validation_command",
-            )
-            if not credentials.get(field)
-        )
-        errors.extend(
-            f"credentialed products require command {item}"
-            for item in ("configure", "doctor")
-            if item not in commands
-        )
-    approvals = (
-        data.get("self_improvement", {})
-        .get("governance", {})
-        .get("human_approval", {})
-    )
-    missing_approvals = sorted(
-        name for name in REQUIRED_APPROVALS if approvals.get(name) is not True
-    )
-    if missing_approvals:
-        errors.append("missing human approval gates: " + ", ".join(missing_approvals))
-    missing_guarantees = sorted(
-        REQUIRED_GUARANTEES - set(data.get("agent", {}).get("guarantees", []))
-    )
-    if missing_guarantees:
-        errors.append(
-            "missing agent guarantees: " + ", ".join(missing_guarantees)
-        )
-    errors.extend(
-        f"missing repository evidence: {label}" for label in evidence(data)
-    )
+    """Run validation and print an actionable result."""
+    try:
+        errors = validate()
+    except (OSError, ValueError, json.JSONDecodeError, yaml.YAMLError) as exc:
+        errors = [str(exc)]
     if errors:
         print("AI-native platform validation failed:")
         for error in errors:


### PR DESCRIPTION
## Summary

- migrate `AI_NATIVE_PLATFORM.yaml` to the canonical v0.1 profile-aware schema
- pin the standard to immutable commit `585484a227741a9eac78393e631b9d3794b85ec8`
- vendor the exact schema snapshot used by CI
- replace the legacy heuristic validator with schema, semantic, and repository-evidence validation
- preserve product-surface, evaluation, and release-metadata checks
- add CodeQL v4 security analysis

## Profile

`full-platform`: SDK, CLI, Codex plugin, MCP, JSON Schema, governed autonomy, and local-only credentials.

## Validation

The migrated repository fixture passes the canonical `ai-native` v0.1 validator at 100/100. This PR must also pass PermutiveAPI's existing test, typing, evaluation, packaging, and release gates before merge.