### PR TITLE
Document final roadmap validation gates

### DIFF
--- a/docs/roadmaps/README.md
+++ b/docs/roadmaps/README.md
@@ -6,4 +6,6 @@ The planned roadmap is complete. `ROADMAP.md` and GitHub issue #188 remain the c
 - 6.6 deterministic platform proof: #186
 - 6.7.0 operational reliability: #187
 
+Every release candidate remains gated by Python CI, AI-native validation, security analysis, package installation checks, and immutable release evidence.
+
 Future roadmap work must begin with verified user demand, an upstream API change, a security finding, or a measured reliability regression. Every accepted item must preserve the canonical SDK, remain backward compatible unless explicitly approved, and include tests, documentation, and machine-readable evidence.


### PR DESCRIPTION
Adds the explicit validation gates that remain mandatory after roadmap completion. This PR exists on the roadmap branch so GitHub creates a native server-side branch update and runs the full protected matrix on PR #213.