### PR TITLE
Release 6.7.1 to recover PyPI publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to PermutiveAPI are documented here. The project follows Semantic Versioning.
 
+## 6.7.1 - 2026-08-24
+
+### Fixed
+- Republished the completed 6.7 release line as a new immutable patch version after the public PyPI index no longer exposed 6.7.0.
+- Kept the 6.7.0 product, API, security, typing, and operational-reliability behavior unchanged.
+
 ## 6.7.0 - 2026-08-06
 
 ### Added

--- a/docs/releases/6.7.1.md
+++ b/docs/releases/6.7.1.md
@@ -1,0 +1,17 @@
+# PermutiveAPI 6.7.1
+
+Released 2026-08-24.
+
+## Purpose
+
+6.7.1 is an immutable recovery release for the completed 6.7 product line. The public PyPI index no longer exposed 6.7.0 even though the repository retained the 6.7.0 tag, GitHub Release, and release evidence.
+
+## Changes
+
+- Republishes the completed 6.7 product surface under a new patch version.
+- Preserves the 6.7.0 API, security, typing, AI-native, and operational-reliability behavior.
+- Contains no intentional product or compatibility changes beyond release metadata.
+
+## Release contract
+
+The release must pass the existing protected CI matrix, exact-artifact validation, SBOM and attestation generation, PyPI Trusted Publishing, and GitHub Release creation before it is considered complete.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PermutiveAPI"
-version = "6.7.0"
+version = "6.7.1"
 description = "A typed, governed AI-native Python platform for the Permutive API."
 readme = "README.md"
 authors = [{ name = "FaTmamBo33", email = "fatmambo33@gmail.com" }]


### PR DESCRIPTION
## Outcome
Publish a new immutable 6.7.1 patch because the public PyPI index no longer exposes 6.7.0.

## Changes
- bump package metadata from 6.7.0 to 6.7.1
- add a dated 6.7.1 changelog entry
- add 6.7.1 release notes required by the release metadata gate
- preserve the shipped 6.7.0 product/API behavior unchanged

## Release behavior
Merging to `main` triggers the existing `Release Python package` workflow, which rebuilds and validates the exact artifacts, publishes through PyPI Trusted Publishing, and creates the matching GitHub tag/release.