### PR TITLE
Verify releases from public PyPI

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -189,9 +189,55 @@ jobs:
         with:
           packages-dir: release-dist
 
-  release:
+  post_publish:
     needs: [check, build, publish]
     if: ${{ always() && needs.build.result == 'success' && (needs.publish.result == 'success' || needs.publish.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install exact release from public PyPI
+        env:
+          PROJECT: ${{ needs.check.outputs.project }}
+          VERSION: ${{ needs.check.outputs.version }}
+        run: |
+          python -m venv .venv-public
+          .venv-public/bin/python -m pip install --upgrade pip
+
+          for attempt in 1 2 3 4 5 6; do
+            if .venv-public/bin/python -m pip install \
+              --no-cache-dir \
+              --index-url https://pypi.org/simple \
+              "${PROJECT}==${VERSION}"; then
+              break
+            fi
+            if [ "$attempt" -eq 6 ]; then
+              echo "${PROJECT}==${VERSION} is not installable from public PyPI." >&2
+              exit 1
+            fi
+            sleep 10
+          done
+      - name: Smoke test public PyPI installation
+        env:
+          PROJECT: ${{ needs.check.outputs.project }}
+          VERSION: ${{ needs.check.outputs.version }}
+        run: |
+          .venv-public/bin/python - <<'PY'
+          import importlib
+          import os
+          from importlib.metadata import version
+
+          package = importlib.import_module(os.environ["PACKAGE_IMPORT"])
+          assert version(os.environ["PROJECT"]) == os.environ["VERSION"]
+          assert package.API_CONTRACT_VERSION == 1
+          assert package.RELEASE_EVIDENCE_VERSION == 1
+          PY
+          .venv-public/bin/permutiveapi --help >/dev/null
+
+  release:
+    needs: [check, build, publish, post_publish]
+    if: ${{ always() && needs.build.result == 'success' && (needs.publish.result == 'success' || needs.publish.result == 'skipped') && needs.post_publish.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Add a post-publication release gate that installs the exact package version from the public PyPI index in a fresh virtual environment, verifies package metadata and release contract constants, and smoke-tests the CLI. The GitHub release step now requires this public-PyPI verification to succeed. The install retries briefly to tolerate index propagation immediately after Trusted Publishing.