### PR TITLE
Redact URL credentials from recordings

### DIFF
--- a/src/PermutiveAPI/recording.py
+++ b/src/PermutiveAPI/recording.py
@@ -237,7 +237,10 @@ def sanitize_json(value: JSONValue) -> JSONValue:
 
 def _safe_endpoint(url: str) -> str:
     parsed = urlsplit(url)
-    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", ""))
+    # User information is unusual in API URLs, but retaining it would leak
+    # embedded credentials into an artifact whose contract is secret-safe.
+    safe_netloc = parsed.netloc.rsplit("@", 1)[-1]
+    return urlunsplit((parsed.scheme, safe_netloc, parsed.path, "", ""))
 
 
 def _safe_headers(headers: Mapping[str, str]) -> dict[str, str]:

--- a/tests/test_contracts_recording.py
+++ b/tests/test_contracts_recording.py
@@ -135,7 +135,7 @@ def test_recording_sanitizes_nested_secrets_and_query_data() -> None:
     transport = RecordingTransport(Transport())
     transport.request(
         "GET",
-        "https://example.test/cohorts-api/v2/cohorts?k=secret#fragment",
+        "https://user:password@example.test/cohorts-api/v2/cohorts?k=secret#fragment",
     )
     interaction = transport.recording.interactions[0]
 


### PR DESCRIPTION
### Motivation
- Prevent embedded userinfo in request URLs from leaking credentials into recorded artifacts by removing URL user information when persisting endpoints.

### Description
- Update `_safe_endpoint` in `src/PermutiveAPI/recording.py` to strip userinfo from the network location portion of URLs before normalizing and storing endpoints.
- Extend `tests/test_contracts_recording.py` to include a URL with `user:password@` and assert that the persisted endpoint is secret-safe and that response headers/body sensitive fields are redacted.

### Testing
- Ran the focused contract recording tests with `pytest -q -o addopts='' tests/test_contracts_recording.py` and they passed (6 passed). 
- Ran style/type checks `black --check` on the modified files and `pyright src/PermutiveAPI/recording.py`, both succeeded for the changed files; `pydocstyle` was not available in the environment. 
- Attempted a full test run with `python -m pytest -q` but collection failed due to missing optional dependencies (`pandas`, `pytest-asyncio`) in the execution environment, and installing dev dependencies failed due to the environment's package-index restrictions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8cc4d00e2c832c83ece26b0c825f80)