### PR TITLE
Release PermutiveAPI 6.8.1 recovery patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to PermutiveAPI are documented here. The project follows Semantic Versioning.
 
+## 6.8.1 - 2026-08-25
+
+### Fixed
+- Published the five post-merge 6.8 review fixes that landed on `main` after the immutable 6.8.0 artifact had already been built.
+- Made canonical sync resource facades derive their transport paths from the typed resource registry instead of duplicating endpoint strings.
+- Corrected integration governance metadata so plain tool discovery is not mislabeled as governed invocation.
+- Strengthened public-surface classification and consolidation tests to prevent export drift and incomplete compatibility classification.
+- Extended clean-wheel CI validation to import the 6.8 consolidation modules from the built distribution.
+
+### Release integrity
+- 6.8.1 is the canonical corrected 6.8 patch and is built from the post-review `main` state.
+- 6.8.0 remains immutable and valid as published, but does not contain the post-merge review fixes above.
+
 ## 6.8.0 - 2026-08-25
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ PermutiveAPI is a typed, governed AI-native Python platform for the Permutive AP
 
 Make PermutiveAPI the most trustworthy and easiest way for Python developers and governed AI agents to operate Permutive safely, with one canonical contract per capability.
 
-## 6.8.0 — lean first-class SDK consolidation
+## 6.8 — lean first-class SDK consolidation
 
 Tracking issue: #218
 
@@ -19,7 +19,13 @@ Tracking issue: #218
 - [x] #225 — Add regression tests for contract drift, duplicate operations, classification completeness, and reproducibility.
 - [x] #226 — Reuse the existing protected CI/release gates for the exact 6.8 candidate rather than adding another workflow family.
 - [x] #227 — Publish one concise 6.8 consolidation/release guide while preserving canonical workflow documentation.
-- [x] #228 — Prepare the exact 6.8.0 release candidate; close only after public PyPI verification succeeds.
+- [ ] #228 — Publish and publicly verify the corrected 6.8.1 recovery patch before closing the 6.8 roadmap.
+
+### 6.8 release status
+
+- 6.8.0 was published from the consolidation commit before the five post-merge review fixes on `main` were included.
+- 6.8.1 is the canonical recovery patch that packages the corrected post-review `main` state.
+- #218 and #228 close only after 6.8.1 is installable from public PyPI and its GitHub release evidence matches the published artifact.
 
 ### 6.8 design rules
 

--- a/docs/releases/6.8.1.md
+++ b/docs/releases/6.8.1.md
@@ -1,0 +1,21 @@
+# PermutiveAPI 6.8.1
+
+PermutiveAPI 6.8.1 is the recovery patch for the 6.8 consolidation release. The immutable 6.8.0 artifact was published from the consolidation commit before the five post-merge review fixes on `main` were included. This patch publishes those fixes from the corrected `main` state.
+
+## Fixed
+
+- Canonical synchronous resource facades now derive endpoint paths from the typed resource registry rather than duplicating transport strings.
+- Integration metadata no longer labels plain tool discovery as governed invocation.
+- Public-surface classification is stricter and covers compatibility/export edge cases found during post-merge review.
+- Consolidation regression tests better detect export drift, registry inconsistencies, and incomplete classification.
+- Clean-wheel CI validation explicitly imports the 6.8 consolidation modules from the built artifact.
+
+## Compatibility
+
+6.8.1 is a backward-compatible patch release. It removes no supported 6.x imports or behaviors and does not introduce a new client, transport, query, plugin, resource, or governance model.
+
+## Release integrity
+
+The 6.8.1 candidate must be built from the current corrected `main`, pass the protected Python 3.9–3.13, typing, documentation, package, security, AI-native, and release-evidence gates, publish through PyPI Trusted Publishing, install successfully from public PyPI in a clean environment, and produce matching GitHub release evidence.
+
+6.8.0 remains immutable as published. Users who want the complete reviewed 6.8 implementation should use 6.8.1 or later.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PermutiveAPI"
-version = "6.8.0"
+version = "6.8.1"
 description = "A typed, governed AI-native Python platform for the Permutive API."
 readme = "README.md"
 authors = [{ name = "FaTmamBo33", email = "fatmambo33@gmail.com" }]


### PR DESCRIPTION
## Summary

Publish the corrected post-review 6.8 state as 6.8.1 because the immutable 6.8.0 artifact was built before the five post-merge review fixes on `main` landed.

## Changes

- bump package version to 6.8.1
- document the five post-merge fixes in the changelog
- add dedicated 6.8.1 release notes
- make the roadmap accurately gate closure on public 6.8.1 verification

## Release gate

Merge only after protected CI is green. After merge, the existing Trusted Publishing workflow must build from the merge commit, publish 6.8.1, verify installation from public PyPI, and create matching GitHub release evidence.

Closes #228 after public publication verification; contributes to #218.